### PR TITLE
zsh functions: peco を fzf に置き換え

### DIFF
--- a/.zsh/functions/_todaymd
+++ b/.zsh/functions/_todaymd
@@ -1,6 +1,6 @@
 #compdef todaymd
 local -a subcmds
 subcmds=('list:list markdown files in TODAYMD_DIR'\
-         'search:search and open file with peco'\
-         'rm:search and remove file with peco')
+         'edit:search and edit file with fzf'\
+         'rm:search and remove file with fzf')
 _describe 'command' subcmds

--- a/.zsh/functions/tmx
+++ b/.zsh/functions/tmx
@@ -18,15 +18,15 @@ Options:
 
 Dependencies:
     tmux
-    peco
+    fzf
 EOF
 }
 
 _ymt_tmx_switch() {
   local session=${1}
   if [ -z "${session}" ]; then
-    # 未指定の場合 peco から選択
-    session="$(tmux list-sessions | peco --prompt='session >' | cut -d : -f 1)"
+    # 未指定の場合 fzf から選択
+    session="$(tmux list-sessions | fzf --prompt='session >' | cut -d : -f 1)"
   fi
 
   if [ -n "$session" ]; then

--- a/.zsh/functions/todaymd
+++ b/.zsh/functions/todaymd
@@ -7,8 +7,8 @@ todaymd creates a markdown file with a date prefix in the specified directory, a
 Usage:
     todaymd           create matkdown with CLI Editor
     todaymd list      list markdown files in TODAYMD_DIR
-    todaymd edit      search and edit file with peco
-    todaymd rm        search and remove file with peco
+    todaymd edit      search and edit file with fzf
+    todaymd rm        search and remove file with fzf
 
 Options:
     --help, -h        print help
@@ -17,7 +17,7 @@ Configurable Environment Variables:
   TODAYMD_DIR=path/to/default/save/dir
 
 Dependencies:
-    peco
+    fzf
     tmux
     vim
 EOF
@@ -79,7 +79,7 @@ _ymt_todaymd_edit() {
     return 1
   fi
 
-  file=$(find "${TODAYMD_DIR}" -name \*.md -type f -exec basename {} \; | sort -r | peco --prompt='file >')
+  file=$(find "${TODAYMD_DIR}" -name \*.md -type f -exec basename {} \; | sort -r | fzf --prompt='file >')
   if [[ -n "$file" ]]; then
     if ! command -v vim >/dev/null 2>&1; then
       echo "Error: vim is not installed" >&2
@@ -97,7 +97,7 @@ _ymt_todaymd_rm() {
     return 1
   fi
 
-  file=$(find "${TODAYMD_DIR}" -name \*.md -type f -exec basename {} \; | sort -r | peco --prompt='file >')
+  file=$(find "${TODAYMD_DIR}" -name \*.md -type f -exec basename {} \; | sort -r | fzf --prompt='file >')
   if [[ -n "$file" ]]; then
     rm -i "${TODAYMD_DIR}/${file}"
   fi


### PR DESCRIPTION
## Summary
- `.zsh/functions` 内の関数で使用している peco を fzf に置き換えました
- 対話的な選択機能はそのまま維持し、ツールのみを変更しています

## 変更内容
### `todaymd` - 日付付きマークダウンファイル管理
- ヘルプメッセージの依存関係を peco → fzf に更新
- `edit` コマンド: ファイル選択に fzf を使用
- `rm` コマンド: ファイル選択に fzf を使用

### `tmx` - tmux セッション管理
- ヘルプメッセージの依存関係を peco → fzf に更新
- セッション選択時に fzf を使用

### `_todaymd` - zsh 補完
- 補完説明を peco → fzf に更新
- サブコマンド名を修正 (search → edit)

## Test plan
- [ ] `todaymd edit` コマンドで fzf によるファイル選択が動作すること
- [ ] `todaymd rm` コマンドで fzf によるファイル選択が動作すること
- [ ] `tmx` コマンドで fzf によるセッション選択が動作すること
- [ ] zsh 補完が正しく動作すること

🤖 Generated with [Claude Code](https://claude.ai/code)