### PR TITLE
Alacritty設定の改善と最適化

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -3,12 +3,12 @@ live_config_reload = true
 import = ["/Users/yuya.matsushima/.config/alacritty/e2esound.toml"]
 
 [bell]
-duration = 0
+duration = 100
 
 [cursor]
 thickness = 0.15
 unfocused_hollow = true
-vi_mode_style = "None"
+vi_mode_style = "Block"
 
 [cursor.style]
 blinking = "Off"
@@ -19,7 +19,7 @@ TERM = "alacritty-direct"
 
 [font]
 builtin_box_drawing = true
-size = 16.0
+size = 14.0
 
 [font.bold]
 family = "JetbrainsMono Nerd Font"
@@ -52,7 +52,7 @@ enabled = true
 mods = "Control"
 
 [scrolling]
-history = 10000
+history = 50000
 multiplier = 5
 
 [selection]
@@ -76,3 +76,20 @@ lines = 50
 [window.padding]
 x = 5
 y = 5
+
+# tmux を併用するためコメントアウト
+# [[keyboard.bindings]]
+# key = "V"
+# mods = "Command"
+# action = "Paste"
+
+# [[keyboard.bindings]]
+# key = "C"
+# mods = "Command"
+# action = "Copy"
+
+[[keyboard.bindings]]
+key = "N"
+mods = "Command"
+action = "SpawnNewInstance"
+

--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,7 +1,7 @@
 
 [general]
 live_config_reload = true
-import = ["/Users/yuya.matsushima/.config/alacritty/e2esound.toml"]
+import = ["~/.config/alacritty/e2esound.toml"]
 
 [bell]
 duration = 0

--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,9 +1,12 @@
 
+[general]
 live_config_reload = true
 import = ["/Users/yuya.matsushima/.config/alacritty/e2esound.toml"]
 
 [bell]
-duration = 100
+duration = 0
+animation = "EaseOutExpo"
+color = "#404040"
 
 [cursor]
 thickness = 0.15

--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,4 +1,7 @@
 
+live_config_reload = true
+import = ["/Users/yuya.matsushima/.config/alacritty/e2esound.toml"]
+
 [bell]
 duration = 0
 
@@ -73,7 +76,3 @@ lines = 50
 [window.padding]
 x = 5
 y = 5
-
-[general]
-live_config_reload = true
-import = ["/Users/yuya.matsushima/.config/alacritty/e2esound.toml"]


### PR DESCRIPTION
## Summary
- Alacritty v0.15.1の非推奨設定を修正
- Claude Code使用に適した設定に最適化
- 環境非依存な設定に改善

## Changes
### 非推奨設定の修正
- `[general]`セクションを廃止し、`live_config_reload`と`import`を適切な場所に配置
- `draw_bold_text_with_bright_colors`を`colors`セクション内に移動

### Claude Code向け最適化
- Vi Modeカーソルスタイルを`Block`に設定
- スクロール履歴を50000行に増加
- フォントサイズを14.0に調整
- 新規ウィンドウ作成キーバインド(Cmd+N)を追加
- tmux併用のためコピペキーバインドをコメントアウト

### ポータビリティ改善
- importパスを絶対パスから`~`を使った相対パスに変更

## Test plan
- [ ] Alacrittyが警告なしで起動することを確認
- [ ] 設定変更がライブリロードされることを確認
- [ ] Vi Mode使用時にカーソルが適切に表示されることを確認
- [ ] Cmd+Nで新規ウィンドウが開くことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)