### PR TITLE
claude-yolo エイリアスに確認プロンプトを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -141,7 +141,7 @@ if (( $+commands[go] )); then
 fi
 (( $+commands[kubectl] )) && source <(kubectl completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
-(( $+commands[claude] )) && alias claude-yolo="claude --dangerous-disable-safety"
+(( $+commands[claude] )) && alias claude-yolo='echo "⚠️  YOLO mode will execute commands without confirmation. Continue? (y/N):" && read -q && echo && claude --dangerous-disable-safety'
 if (( $+commands[fzf] )); then
   source <(fzf --zsh 2>/dev/null) 2>/dev/null || true
   export FZF_DEFAULT_COMMAND="fd --type f --type d --hidden --exclude .git"


### PR DESCRIPTION
## Summary
- claude-yolo実行時にユーザー確認を要求する機能を追加
- 危険なYOLOモード実行前に警告メッセージとy/N選択を表示

## Test plan
- [ ] zshrcをsourceして設定を反映
- [ ] claude-yoloコマンドを実行して確認プロンプトが表示されることを確認
- [ ] nを選択した場合にコマンドがキャンセルされることを確認
- [ ] yを選択した場合にclaude --dangerous-disable-safetyが実行されることを確認

🤖 Generated with Claude Code