### PR TITLE
起動時設定の改善とCopilot制御機能追加

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -20,6 +20,7 @@ shape = "Block"
 [env]
 TERM = "alacritty-direct"
 
+
 [font]
 builtin_box_drawing = true
 size = 14.0

--- a/.vimrc
+++ b/.vimrc
@@ -384,12 +384,18 @@ endif
 
 " GitHub Copilot settings
 if !empty(globpath(&rtp, 'autoload/copilot.vim'))
-  " Enable Copilot for specific filetypes
-  let g:copilot_filetypes = {
-        \ '*': v:true,
-        \ 'gitcommit': v:true,
-        \ 'markdown': v:true,
-        \ }
+  " Check if Copilot should be disabled via environment variable
+  if exists('$DISABLE_COPILOT') && $DISABLE_COPILOT ==# '1'
+    let g:copilot_enabled = v:false
+    let g:copilot_filetypes = { '*': v:false }
+  else
+    " Enable Copilot for specific filetypes
+    let g:copilot_filetypes = {
+          \ '*': v:true,
+          \ 'gitcommit': v:true,
+          \ 'markdown': v:true,
+          \ }
+  endif
 
   " Disable default tab mapping
   let g:copilot_no_tab_map = v:true

--- a/.zshrc
+++ b/.zshrc
@@ -213,4 +213,10 @@ fi
 which less > /dev/null && source $HOME/.zsh/config/less.zsh
 
 [ -f $HOME/.zshrc_local ] && source $HOME/.zshrc_local
+
+# start tmux via tmx for Alacritty only
+if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]] && [[ "$TERM" == "alacritty-direct" ]]; then
+  tmx
+fi
+
 [ -n "$ZSH_PROFILE" ] && zprof | less


### PR DESCRIPTION
## Summary
- Alacritty専用のtmux自動起動設定をzshrcに追加
- vim用のDISABLE_COPILOT環境変数による無効化機能を追加

## Test plan
- [ ] Alacrittyでのみtmux（tmx経由）が自動起動することを確認
- [ ] Terminal.app、iTerm2では自動起動しないことを確認  
- [ ] `DISABLE_COPILOT=1 vim` でCopilotが無効化されることを確認
- [ ] 通常のvim起動時はCopilotが有効なことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)