### PR TITLE
tinyvim エイリアスの追加と.vimrc.minimal の改善

### DIFF
--- a/.vimrc.minimal
+++ b/.vimrc.minimal
@@ -1,6 +1,14 @@
 set fileencodings=utf-8,ucs-bom,sjis,cp932,utf-16,utf-16le
 filetype on
 syntax on
+
+" Load colorscheme if available
+try
+  colorscheme e2esound
+catch /^Vim\%((\a\+)\)\=:E185/
+  " Colorscheme not found, use default
+endtry
+
 filetype indent on
 filetype plugin on
 set iminsert=0

--- a/.zshrc
+++ b/.zshrc
@@ -142,6 +142,10 @@ fi
 (( $+commands[kubectl] )) && source <(kubectl completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
 (( $+commands[claude] )) && alias claude-yolo='echo "⚠️  YOLO mode will execute commands without confirmation. Continue? (y/N):" && read -q && echo && claude --dangerous-disable-safety'
+# tinyvim: vim with minimal configuration
+if [[ -f "$HOME/.vimrc.minimal" || -L "$HOME/.vimrc.minimal" ]]; then
+  alias tinyvim='vim -u "$HOME/.vimrc.minimal"'
+fi
 if (( $+commands[fzf] )); then
   source <(fzf --zsh 2>/dev/null) 2>/dev/null || true
   export FZF_DEFAULT_COMMAND="fd --type f --type d --hidden --exclude .git"

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -25,6 +25,7 @@ TARGETS=( \
          ".tmux.conf" \
          ".vim" \
          ".vimrc" \
+         ".vimrc.minimal" \
          ".gvimrc" \
          ".zsh" \
          ".zshrc" \


### PR DESCRIPTION
## Summary
- `tinyvim` エイリアスを追加 - 最小限の設定でVimを起動
- `.vimrc.minimal` のカラースキーム読み込みを改善

## Changes
- `.zshrc`: `tinyvim` エイリアスを追加（`vim -u ~/.vimrc.minimal`）
  - `$HOME/.vimrc.minimal` の存在チェック付き
- `.vimrc.minimal`: e2esound カラースキームの条件付き読み込みに対応
  - カラースキームが存在しない場合はデフォルトを使用

🤖 Generated with Claude Code