### PR TITLE
Alacritty判定を改善: alacrittyで始まるすべてのTERM値に対応

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -219,7 +219,7 @@ which less > /dev/null && source $HOME/.zsh/config/less.zsh
 [ -f $HOME/.zshrc_local ] && source $HOME/.zshrc_local
 
 # start tmux via tmx for Alacritty only
-if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]] && [[ "$TERM" == "alacritty-direct" ]]; then
+if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]] && [[ "$TERM" == alacritty* ]]; then
   tmx
 fi
 


### PR DESCRIPTION
## Summary
- $TERMが"alacritty-direct"の場合のみでなく、"alacritty"で始まるすべての値に対応するように修正
- Alacrittyのダウンロード方法により"alacritty"または"alacritty-direct"になる問題を解決

## Test plan
- [ ] .zshrcの構文エラーがないことを確認
- [ ] Alacrittyでtmxが正常に起動することを確認

🤖 Generated with [Claude Code](https://claude.ai/code)