### PR TITLE
Hammerspoon: Claude Desktop をCtrl+0で起動するショートカット追加

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -22,6 +22,7 @@ end
 hs.hotkey.bind({ "ctrl" }, "delete", function() toggleApp("Alacritty") end)
 hs.hotkey.bind({ "ctrl" }, "=", function() toggleApp("Inkdrop") end)
 hs.hotkey.bind({ "ctrl" }, "-", function() toggleApp("ChatGPT") end)
+hs.hotkey.bind({ "ctrl" }, "0", function() toggleApp("Claude") end)
 
 -- IME の英字/ひらがなを右 cmd で切り替え
 -- この設定は前提として Mac IME の "日本語-ローマ字入力" を前提


### PR DESCRIPTION
## Summary
- Hammerspoon の設定に Claude Desktop 用のホットキー（Ctrl+0）を追加
- 既存の ChatGPT や Alacritty と同様の toggleApp 関数を使用して実装

## Test plan
- [x] Hammerspoon の設定をリロード
- [x] Ctrl+0 で Claude Desktop が起動することを確認
- [x] 再度 Ctrl+0 で Claude Desktop が最前面に来る/隠れることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)