### PR TITLE
tmux: Git branch表示をステータスラインに追加

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -62,7 +62,9 @@ bind 'c' new-window -c "#{pane_current_path}"
 # status
 set -g status-left-length 20
 set -g status-left "#[fg=colour240] #S #[default]"
-set -g status-right ""
+set -g status-right-length 35
+# Display git branch name in brackets, truncate to 30 chars with ellipsis if too long
+set -g status-right "#[fg=colour240]#(cd #{pane_current_path} 2>/dev/null && branch=\$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [[ -n \$branch ]]; then if [[ \${#branch} -gt 30 ]]; then echo [\${branch:0:29}…]; else echo [\$branch]; fi; fi) #[default]"
 
 # alias
 bind z kill-pane
@@ -83,3 +85,8 @@ bind-key -T copy-mode-vi v send-keys -X begin-selection
 bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
 bind-key -T copy-mode-vi Y send-keys -X copy-line
 bind-key -T copy-mode-vi C-v send-keys -X rectangle-toggle
+
+# hooks for status update
+set-hook -g pane-focus-in 'refresh-client -S'
+set-hook -g window-linked 'refresh-client -S'
+set-hook -g session-window-changed 'refresh-client -S'


### PR DESCRIPTION
## Summary
- tmuxのステータスライン右側にgit branch名を表示する機能を追加
- branch名は最大30文字で表示し、それを超える場合は省略記号で短縮
- ペーンやウィンドウの切り替え時に即座に更新されるようフックを設定

## Test plan
- [x] git リポジトリ内でtmuxを起動し、branch名が表示されることを確認
- [x] 長いbranch名が適切に省略されることを確認
- [x] ペーン/ウィンドウを切り替えた際に即座に更新されることを確認

🤖 Generated with Claude Code