### PR TITLE
zsh: claude-yolo エイリアスのオプションを修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -141,7 +141,7 @@ if (( $+commands[go] )); then
 fi
 (( $+commands[kubectl] )) && source <(kubectl completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
-(( $+commands[claude] )) && alias claude-yolo='echo "⚠️  YOLO mode will execute commands without confirmation. Continue? (y/N):" && read -q && echo && claude --dangerous-disable-safety'
+(( $+commands[claude] )) && alias claude-yolo='echo "⚠️  YOLO mode will execute commands without confirmation. Continue? (y/N):" && read -q && echo && claude --dangerously-skip-permissions'
 # tinyvim: vim with minimal configuration
 if [[ -f "$HOME/.vimrc.minimal" || -L "$HOME/.vimrc.minimal" ]]; then
   alias tinyvim='vim -u "$HOME/.vimrc.minimal"'


### PR DESCRIPTION
## Summary
- `.zshrc` の `claude-yolo` エイリアスで使用していた誤ったオプション `--dangerous-disable-safety` を正しい `--dangerously-skip-permissions` に修正

## Test plan
- [ ] `.zshrc` を source して構文エラーがないことを確認
- [ ] `claude-yolo` エイリアスが正しく動作することを確認

🤖 Generated with Claude Code