### PR TITLE
zsh: Screen Studio録画用のtinypromptモードを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -26,7 +26,7 @@ case ${UID} in
     ;;
 *)
     # シンプルなプロンプト（個人情報を含まない）
-    if [ -n "$TINY_PROMPT" ]; then
+    if [[ "$TINY_PROMPT" == "1" ]]; then
         PROMPT="%{${fg[cyan]}%}$ %{${reset_color}%}"
         PROMPT2="%{${fg[red]}%}> %{${reset_color}%}"
         SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "

--- a/.zshrc
+++ b/.zshrc
@@ -153,6 +153,7 @@ fi
 (( $+commands[claude] )) && alias claude-yolo='echo "⚠️  YOLO mode will execute commands without confirmation. Continue? (y/N):" && read -q && echo && claude --dangerously-skip-permissions'
 # Tiny prompt mode for screen recording
 alias tinyprompt='export TINY_PROMPT=1 && exec zsh'
+alias normalprompt='unset TINY_PROMPT && exec zsh'
 # tinyvim: vim with minimal configuration
 if [[ -f "$HOME/.vimrc.minimal" || -L "$HOME/.vimrc.minimal" ]]; then
   alias tinyvim='vim -u "$HOME/.vimrc.minimal"'

--- a/.zshrc
+++ b/.zshrc
@@ -25,11 +25,18 @@ case ${UID} in
     SPROMPT="%B%{${fg[white]}%}%r is correct? [n,y,a,e]:%{${reset_color}%}%b "
     ;;
 *)
-    PROMPT="%{${fg[cyan]}%}%30<~<%/%%%{${reset_color}%} "
-    PROMPT2="%{${fg[red]}%}%_%%%{${reset_color}%} "
-    SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
-    [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] &&
-        PROMPT="%{${fg[red]}%}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') ${PROMPT}"
+    # シンプルなプロンプト（個人情報を含まない）
+    if [ -n "$TINY_PROMPT" ]; then
+        PROMPT="%{${fg[cyan]}%}$ %{${reset_color}%}"
+        PROMPT2="%{${fg[red]}%}> %{${reset_color}%}"
+        SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
+    else
+        PROMPT="%{${fg[cyan]}%}%30<~<%/%%%{${reset_color}%} "
+        PROMPT2="%{${fg[red]}%}%_%%%{${reset_color}%} "
+        SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
+        [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] &&
+            PROMPT="%{${fg[red]}%}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') ${PROMPT}"
+    fi
     ;;
 esac
 
@@ -144,6 +151,8 @@ fi
 # Use local claude installation if available
 [[ -x "$HOME/.claude/local/claude" ]] && alias claude="$HOME/.claude/local/claude"
 (( $+commands[claude] )) && alias claude-yolo='echo "⚠️  YOLO mode will execute commands without confirmation. Continue? (y/N):" && read -q && echo && claude --dangerously-skip-permissions'
+# Tiny prompt mode for screen recording
+alias tinyprompt='export TINY_PROMPT=1 && exec zsh'
 # tinyvim: vim with minimal configuration
 if [[ -f "$HOME/.vimrc.minimal" || -L "$HOME/.vimrc.minimal" ]]; then
   alias tinyvim='vim -u "$HOME/.vimrc.minimal"'

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -17,11 +17,18 @@ case ${UID} in
     SPROMPT="%B%{${fg[white]}%}%r is correct? [n,y,a,e]:%{${reset_color}%}%b "
     ;;
 *)
-    PROMPT="%{${fg[cyan]}%}%30<~<%/%%%{${reset_color}%} "
-    PROMPT2="%{${fg[red]}%}%_%%%{${reset_color}%} "
-    SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
-    [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] &&
-        PROMPT="%{${fg[red]}%}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') ${PROMPT}"
+    # シンプルなプロンプト（個人情報を含まない）
+    if [ -n "$TINY_PROMPT" ]; then
+        PROMPT="%{${fg[cyan]}%}$ %{${reset_color}%}"
+        PROMPT2="%{${fg[red]}%}> %{${reset_color}%}"
+        SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
+    else
+        PROMPT="%{${fg[cyan]}%}%30<~<%/%%%{${reset_color}%} "
+        PROMPT2="%{${fg[red]}%}%_%%%{${reset_color}%} "
+        SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "
+        [ -n "${REMOTEHOST}${SSH_CONNECTION}" ] &&
+            PROMPT="%{${fg[red]}%}$(echo ${HOST%%.*} | tr '[a-z]' '[A-Z]') ${PROMPT}"
+    fi
     ;;
 esac
 
@@ -99,6 +106,8 @@ fi
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
 # tealdeer: tldr client
 (( $+commands[tldr] )) && alias tldr="tldr --language=en"
+# Tiny prompt mode for screen recording
+alias tinyprompt='export TINY_PROMPT=1 && exec zsh'
 
 case "${TERM}" in
 screen)

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -108,6 +108,7 @@ fi
 (( $+commands[tldr] )) && alias tldr="tldr --language=en"
 # Tiny prompt mode for screen recording
 alias tinyprompt='export TINY_PROMPT=1 && exec zsh'
+alias normalprompt='unset TINY_PROMPT && exec zsh'
 
 case "${TERM}" in
 screen)

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -18,7 +18,7 @@ case ${UID} in
     ;;
 *)
     # シンプルなプロンプト（個人情報を含まない）
-    if [ -n "$TINY_PROMPT" ]; then
+    if [[ "$TINY_PROMPT" == "1" ]]; then
         PROMPT="%{${fg[cyan]}%}$ %{${reset_color}%}"
         PROMPT2="%{${fg[red]}%}> %{${reset_color}%}"
         SPROMPT="%{${fg[red]}%}%r is correct? [n,y,a,e]:%{${reset_color}%} "


### PR DESCRIPTION
## Summary
- Screen Studio などでの動画撮影時に個人情報を隠すための機能を追加
- `tinyprompt` コマンドでシンプルなプロンプト表示に切り替え
- `normalprompt` コマンドで通常のプロンプトに戻す

## Changes
- TINY_PROMPT 環境変数でプロンプト表示を制御
- tinyprompt 時は現在のディレクトリ情報を表示せず `$ ` のみ表示
- .zshrc と .zshrc.minimal の両方に実装

## Test plan
- [x] `tinyprompt` コマンドを実行してプロンプトがシンプルになることを確認
- [x] `normalprompt` コマンドを実行して通常のプロンプトに戻ることを確認
- [x] 両コマンドが .zshrc と .zshrc.minimal の両方で動作することを確認

🤖 Generated with Claude Code