### PR TITLE
feat: zshのviモードでカーソル形状を変更する機能を追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -83,6 +83,17 @@ bindkey "^n" history-beginning-search-forward-end
 # reverse menu completion binded to Shift-Tab
 bindkey "\e[Z" reverse-menu-complete
 
+# Vi mode cursor shape indicator
+function zle-line-init zle-keymap-select {
+    case $KEYMAP in
+        vicmd)      echo -ne '\e[1 q' ;;  # Block cursor for normal mode
+        viins|main) echo -ne '\e[5 q' ;;  # Beam cursor for insert mode
+    esac
+}
+zle -N zle-line-init
+zle -N zle-keymap-select
+echo -ne '\e[5 q'  # Set beam cursor on startup
+
 # history
 HISTFILE=${HOME}/.zsh_history
 HISTSIZE=250000

--- a/.zshrc
+++ b/.zshrc
@@ -170,12 +170,12 @@ fi
 
 # zsh-vi-mode
 if [[ -f "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh" ]]; then
-  source "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
-  
-  # Explicitly enable cursor styling
+  # Explicitly enable cursor styling (must be set before sourcing the plugin)
   ZVM_CURSOR_STYLE_ENABLED=true
   ZVM_NORMAL_MODE_CURSOR=$ZVM_CURSOR_BLOCK
   ZVM_INSERT_MODE_CURSOR=$ZVM_CURSOR_BEAM
+  
+  source "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
 fi
 
 ## terminal configuration

--- a/.zshrc
+++ b/.zshrc
@@ -83,17 +83,6 @@ bindkey "^n" history-beginning-search-forward-end
 # reverse menu completion binded to Shift-Tab
 bindkey "\e[Z" reverse-menu-complete
 
-# Vi mode cursor shape indicator
-function zle-line-init zle-keymap-select {
-    case $KEYMAP in
-        vicmd)      echo -ne '\e[1 q' ;;  # Block cursor for normal mode
-        viins|main) echo -ne '\e[5 q' ;;  # Beam cursor for insert mode
-    esac
-}
-zle -N zle-line-init
-zle -N zle-keymap-select
-echo -ne '\e[5 q'  # Set beam cursor on startup
-
 # history
 HISTFILE=${HOME}/.zsh_history
 HISTSIZE=250000

--- a/.zshrc
+++ b/.zshrc
@@ -179,6 +179,16 @@ if (( $+commands[fzf] )); then
   [ -f "$HOME/.zsh/fzf.zsh" ] && source "$HOME/.zsh/fzf.zsh"
 fi
 
+# zsh-vi-mode
+if [[ -f "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh" ]]; then
+  source "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
+  
+  # Explicitly enable cursor styling
+  ZVM_CURSOR_STYLE_ENABLED=true
+  ZVM_NORMAL_MODE_CURSOR=$ZVM_CURSOR_BLOCK
+  ZVM_INSERT_MODE_CURSOR=$ZVM_CURSOR_BEAM
+fi
+
 ## terminal configuration
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
 

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -54,6 +54,17 @@ bindkey "^p" history-beginning-search-backward-end
 bindkey "^n" history-beginning-search-forward-end
 bindkey "\e[Z" reverse-menu-complete
 
+# Vi mode cursor shape indicator
+function zle-line-init zle-keymap-select {
+    case $KEYMAP in
+        vicmd)      echo -ne '\e[1 q' ;;  # Block cursor for normal mode
+        viins|main) echo -ne '\e[5 q' ;;  # Beam cursor for insert mode
+    esac
+}
+zle -N zle-line-init
+zle -N zle-keymap-select
+echo -ne '\e[5 q'  # Set beam cursor on startup
+
 # history
 HISTFILE=${HOME}/.zsh_history
 HISTSIZE=250000

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -110,16 +110,6 @@ fi
 alias tinyprompt='export TINY_PROMPT=1 && exec zsh'
 alias normalprompt='unset TINY_PROMPT && exec zsh'
 
-# zsh-vi-mode
-if [[ -f "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh" ]]; then
-  source "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
-  
-  # Explicitly enable cursor styling
-  ZVM_CURSOR_STYLE_ENABLED=true
-  ZVM_NORMAL_MODE_CURSOR=$ZVM_CURSOR_BLOCK
-  ZVM_INSERT_MODE_CURSOR=$ZVM_CURSOR_BEAM
-fi
-
 case "${TERM}" in
 screen)
     TERM=xterm

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -54,17 +54,6 @@ bindkey "^p" history-beginning-search-backward-end
 bindkey "^n" history-beginning-search-forward-end
 bindkey "\e[Z" reverse-menu-complete
 
-# Vi mode cursor shape indicator
-function zle-line-init zle-keymap-select {
-    case $KEYMAP in
-        vicmd)      echo -ne '\e[1 q' ;;  # Block cursor for normal mode
-        viins|main) echo -ne '\e[5 q' ;;  # Beam cursor for insert mode
-    esac
-}
-zle -N zle-line-init
-zle -N zle-keymap-select
-echo -ne '\e[5 q'  # Set beam cursor on startup
-
 # history
 HISTFILE=${HOME}/.zsh_history
 HISTSIZE=250000
@@ -120,6 +109,16 @@ fi
 # Tiny prompt mode for screen recording
 alias tinyprompt='export TINY_PROMPT=1 && exec zsh'
 alias normalprompt='unset TINY_PROMPT && exec zsh'
+
+# zsh-vi-mode
+if [[ -f "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh" ]]; then
+  source "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
+  
+  # Explicitly enable cursor styling
+  ZVM_CURSOR_STYLE_ENABLED=true
+  ZVM_NORMAL_MODE_CURSOR=$ZVM_CURSOR_BLOCK
+  ZVM_INSERT_MODE_CURSOR=$ZVM_CURSOR_BEAM
+fi
 
 case "${TERM}" in
 screen)


### PR DESCRIPTION
## Summary
- zsh-vi-modeプラグインを導入し、viモードの操作性を大幅に向上
- カーソル形状でモードを視覚的に確認可能（インサートモード: ビーム、コマンドモード: ブロック）
- サラウンド操作、ビジュアルモード、エディタ編集など高度な機能が利用可能に

## Changes
- Homebrewでzsh-vi-modeをインストール
- `.zshrc`にプラグインの読み込みとカーソル設定を追加

## Test plan
- [x] `source ~/.zshrc`でエラーが出ないことを確認
- [x] ESCキーでviコマンドモードに切り替えた際、カーソルがブロック形状になることを確認
- [x] `i`や`a`でインサートモードに戻った際、カーソルがビーム形状になることを確認
- [x] `vv`でコマンドラインをエディタで編集できることを確認

🤖 Generated with Claude Code