### PR TITLE
feat: zsh-vi-modeをHomebrewのCLIツールに追加

### DIFF
--- a/bin/homebrew/cli.sh
+++ b/bin/homebrew/cli.sh
@@ -41,4 +41,5 @@ brew install \
           wget \
           zsh \
           zsh-completions \
-          zsh-git-prompt
+          zsh-git-prompt \
+          zsh-vi-mode


### PR DESCRIPTION
## Summary
- `bin/homebrew/cli.sh`にzsh-vi-modeを追加しました
- zshのviモード機能を強化するためのプラグインです

## Test plan
- [ ] `make cli`でzsh-vi-modeがインストールされることを確認
- [ ] インストール後、zshでviモードが正しく動作することを確認

🤖 Generated with Claude Code