### PR TITLE
fix: zsh-vi-modeを削除してctrl+p/nの履歴検索を修正

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -168,16 +168,6 @@ if (( $+commands[fzf] )); then
   [ -f "$HOME/.zsh/fzf.zsh" ] && source "$HOME/.zsh/fzf.zsh"
 fi
 
-# zsh-vi-mode
-if [[ -f "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh" ]]; then
-  # Explicitly enable cursor styling (must be set before sourcing the plugin)
-  ZVM_CURSOR_STYLE_ENABLED=true
-  ZVM_NORMAL_MODE_CURSOR=$ZVM_CURSOR_BLOCK
-  ZVM_INSERT_MODE_CURSOR=$ZVM_CURSOR_BEAM
-  
-  source "$HOMEBREW_PREFIX/opt/zsh-vi-mode/share/zsh-vi-mode/zsh-vi-mode.plugin.zsh"
-fi
-
 ## terminal configuration
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'
 

--- a/bin/homebrew/cli.sh
+++ b/bin/homebrew/cli.sh
@@ -41,5 +41,4 @@ brew install \
           wget \
           zsh \
           zsh-completions \
-          zsh-git-prompt \
-          zsh-vi-mode
+          zsh-git-prompt


### PR DESCRIPTION
## Summary
- zsh-vi-modeプラグインがctrl+p/ctrl+nのキーバインディングを上書きしていた問題を修正
- zsh-vi-modeは特に便利ではなかったため削除

## Changes
- `bin/homebrew/cli.sh`: zsh-vi-modeパッケージを削除
- `.zshrc`: zsh-vi-modeプラグインの設定を削除（171-179行目）

## Test plan
- [ ] `source ~/.zshrc`でエラーが発生しないことを確認
- [ ] ctrl+p/ctrl+nで履歴検索が正常に動作することを確認
- [ ] 部分文字列を入力してからctrl+pを押すと、その文字列で始まるコマンド履歴が表示されることを確認

🤖 Generated with Claude Code