### PR TITLE
feat: webdataコマンドでsitemap.xmlを保存対象に追加

### DIFF
--- a/.zsh/bin/webdata-node/index.js
+++ b/.zsh/bin/webdata-node/index.js
@@ -538,6 +538,11 @@ async function main() {
       // Create README.md
       await createReadme(outputDir, url, devicesToCapture, true, urls);
 
+      // Save sitemap.xml
+      const sitemapPath = path.join(outputDir, 'sitemap.xml');
+      await fs.writeFile(sitemapPath, xmlContent, 'utf8');
+      console.log(`Sitemap saved: ${sitemapPath}`);
+
       // Process URLs concurrently for all devices
       await processUrlsConcurrently(urls, browser, outputDir, devicesToCapture, concurrentLimit);
     } else {

--- a/.zsh/bin/webdata-node/templates/README.md
+++ b/.zsh/bin/webdata-node/templates/README.md
@@ -19,6 +19,7 @@
 ```
 ./
 ├── README.md           # This file
+├── sitemap.xml         # Original sitemap.xml (if captured from sitemap)
 ├── captures/           # Screenshot images (PNG)
 {{DEVICE_TREE}}
 └── markdown/           # Text content (Markdown)
@@ -59,8 +60,9 @@ This directory contains website data captured for LLM processing:
 1. **Screenshots**: Visual representation of pages in different device sizes
 2. **Markdown**: Clean text content extracted from HTML
 3. **Structure**: Organized by URL path for easy navigation
+4. **Sitemap**: Original sitemap.xml file (if source was a sitemap) containing all page URLs
 
-You can reference screenshots and markdown files to understand the website structure and content. The markdown files contain the main textual content, while screenshots provide visual context for layout and design elements.
+You can reference screenshots and markdown files to understand the website structure and content. The markdown files contain the main textual content, while screenshots provide visual context for layout and design elements. When analyzing a site captured from sitemap.xml, you can use the sitemap.xml file to understand the complete site structure and available pages.
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- sitemap.xmlから取得した場合、元のsitemap.xmlをoutputディレクトリに保存するようにしました
- READMEテンプレートを更新し、LLMがsitemap.xmlを活用できるよう説明を追加しました

## Test plan
- [x] `webdata https://example.com/sitemap.xml` を実行
- [x] outputディレクトリにsitemap.xmlが保存されることを確認
- [x] READMEにsitemap.xmlの説明が含まれることを確認
- [x] 通常のURL（非sitemap）でも正常に動作することを確認

🤖 Generated with Claude Code