### PR TITLE
feat: webdataコマンドでsitemap index形式に対応

### DIFF
--- a/.zsh/bin/webdata-node/templates/README.md
+++ b/.zsh/bin/webdata-node/templates/README.md
@@ -19,7 +19,9 @@
 ```
 ./
 ├── README.md           # This file
-├── *.xml               # Sitemap files (if captured from sitemap/sitemap index)
+├── sitemap/            # Sitemap files (if captured from sitemap/sitemap index)
+│   ├── sitemap.xml     # Main sitemap or sitemap index
+│   └── ...             # Child sitemaps with directory structure preserved
 ├── captures/           # Screenshot images (PNG)
 {{DEVICE_TREE}}
 └── markdown/           # Text content (Markdown)
@@ -60,15 +62,20 @@ This directory contains website data captured for LLM processing:
 1. **Screenshots**: Visual representation of pages in different device sizes
 2. **Markdown**: Clean text content extracted from HTML
 3. **Structure**: Organized by URL path for easy navigation
-4. **Sitemap files**: 
-   - For regular sitemaps: Original sitemap.xml containing all page URLs
-   - For sitemap indexes: All sitemap files including the index and child sitemaps
+4. **Sitemap files** (in `sitemap/` directory): 
+   - For regular sitemaps: `sitemap/sitemap.xml` containing all page URLs
+   - For sitemap indexes: All XML files with directory structure preserved
+     - `sitemap/sitemap.xml` - Main sitemap index
+     - Child sitemaps maintain their original path structure (e.g., `sitemap/sitemaps/posts.xml`)
 
 You can reference screenshots and markdown files to understand the website structure and content. The markdown files contain the main textual content, while screenshots provide visual context for layout and design elements.
 
 When analyzing a site captured from a sitemap:
-- **Regular sitemap**: Use the sitemap.xml file to understand the complete site structure
-- **Sitemap index**: Multiple XML files are saved - the index file lists all child sitemaps, and each child sitemap contains actual page URLs
+- **Regular sitemap**: Check `sitemap/sitemap.xml` for the complete site structure
+- **Sitemap index**: The `sitemap/` directory contains all XML files:
+  - The main index file shows available child sitemaps
+  - Each child sitemap contains actual page URLs
+  - Directory structure is preserved to match the original site organization
 
 ## Notes
 

--- a/.zsh/bin/webdata-node/templates/README.md
+++ b/.zsh/bin/webdata-node/templates/README.md
@@ -19,7 +19,7 @@
 ```
 ./
 ├── README.md           # This file
-├── sitemap.xml         # Original sitemap.xml (if captured from sitemap)
+├── *.xml               # Sitemap files (if captured from sitemap/sitemap index)
 ├── captures/           # Screenshot images (PNG)
 {{DEVICE_TREE}}
 └── markdown/           # Text content (Markdown)
@@ -60,9 +60,15 @@ This directory contains website data captured for LLM processing:
 1. **Screenshots**: Visual representation of pages in different device sizes
 2. **Markdown**: Clean text content extracted from HTML
 3. **Structure**: Organized by URL path for easy navigation
-4. **Sitemap**: Original sitemap.xml file (if source was a sitemap) containing all page URLs
+4. **Sitemap files**: 
+   - For regular sitemaps: Original sitemap.xml containing all page URLs
+   - For sitemap indexes: All sitemap files including the index and child sitemaps
 
-You can reference screenshots and markdown files to understand the website structure and content. The markdown files contain the main textual content, while screenshots provide visual context for layout and design elements. When analyzing a site captured from sitemap.xml, you can use the sitemap.xml file to understand the complete site structure and available pages.
+You can reference screenshots and markdown files to understand the website structure and content. The markdown files contain the main textual content, while screenshots provide visual context for layout and design elements.
+
+When analyzing a site captured from a sitemap:
+- **Regular sitemap**: Use the sitemap.xml file to understand the complete site structure
+- **Sitemap index**: Multiple XML files are saved - the index file lists all child sitemaps, and each child sitemap contains actual page URLs
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- sitemap index形式のXMLファイルに対応
- 再帰的に子サイトマップを取得して全URLを処理
- sitemapファイルを専用ディレクトリに整理して保存

## Changes
- `parseSitemap()`関数を拡張してsitemap indexを検出
- `fetchSitemapIndex()`関数を追加して再帰的な取得を実装
- 全sitemapファイルを`sitemap/`ディレクトリに保存
- sitemap indexの場合は元のディレクトリ構造を維持
- READMEテンプレートを更新して新しい構造を説明

## Test plan
- [x] 通常のsitemap.xmlでの動作確認
- [x] sitemap index形式での動作確認
- [x] 生成されるディレクトリ構造の確認
- [x] READMEの内容確認

🤖 Generated with Claude Code