### PR TITLE
feat: claude-yoloに--only-sandboxオプションを追加

### DIFF
--- a/.zsh/functions/claude-yolo
+++ b/.zsh/functions/claude-yolo
@@ -8,8 +8,9 @@ Usage:
     claude-yolo [options] [claude arguments...]
 
 Options:
-    --profile, -p PATH     specify sandbox profile path
-    --help, -h             print help
+    --profile, -p PATH       specify sandbox profile path
+    --only-sandbox, -os      run with sandbox only (without YOLO mode)
+    --help, -h               print help
 
 Dependencies:
     claude
@@ -19,7 +20,8 @@ EOF
 
 _ymt_claude_yolo_exec() {
   local sandbox_profile="${1}"
-  shift
+  local only_sandbox="${2}"
+  shift 2
   local -a claude_args=("$@")
 
   # Check if claude command is available
@@ -35,18 +37,32 @@ _ymt_claude_yolo_exec() {
   fi
 
   # Display execution info
-  echo "Executing claude command in sandbox with profile: $sandbox_profile"
+  if [[ "$only_sandbox" == "true" ]]; then
+    echo "Executing claude command in sandbox (without YOLO) with profile: $sandbox_profile"
+  else
+    echo "Executing claude command in sandbox with profile: $sandbox_profile"
+  fi
   
   # Execute claude with sandbox restrictions
-  sandbox-exec -f "$sandbox_profile" \
-    -D PWD="$(pwd)" \
-    -D HOME="$HOME" \
-    claude --dangerously-skip-permissions "${claude_args[@]}"
+  if [[ "$only_sandbox" == "true" ]]; then
+    # Run with sandbox only (no YOLO flag)
+    sandbox-exec -f "$sandbox_profile" \
+      -D PWD="$(pwd)" \
+      -D HOME="$HOME" \
+      claude "${claude_args[@]}"
+  else
+    # Run with both sandbox and YOLO mode
+    sandbox-exec -f "$sandbox_profile" \
+      -D PWD="$(pwd)" \
+      -D HOME="$HOME" \
+      claude --dangerously-skip-permissions "${claude_args[@]}"
+  fi
 }
 
 # Default sandbox profile
 local default_profile="$HOME/.zsh/claude/sandbox.sb"
 local profile="$default_profile"
+local only_sandbox="false"
 local -a args=()
 
 # Parse arguments
@@ -64,6 +80,10 @@ while [[ $# -gt 0 ]]; do
       profile="${2}"
       shift 2
       ;;
+    -os|--only-sandbox)
+      only_sandbox="true"
+      shift
+      ;;
     *)
       args+=("${1}")
       shift
@@ -71,4 +91,4 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-_ymt_claude_yolo_exec "$profile" "${args[@]}"
+_ymt_claude_yolo_exec "$profile" "$only_sandbox" "${args[@]}"

--- a/.zsh/functions/claude-yolo
+++ b/.zsh/functions/claude-yolo
@@ -1,7 +1,8 @@
 #!/bin/zsh
 
-_ymt_claude_yolo_usage() {
-  cat <<EOF
+claude-yolo() {
+  _ymt_claude_yolo_usage() {
+    cat <<EOF
 claude-yolo is a command to run Claude Code YOLO mode with sandbox execution.
 
 Usage:
@@ -16,83 +17,80 @@ Dependencies:
     claude
     sandbox-exec (macOS)
 EOF
+  }
+
+  _ymt_claude_yolo_exec() {
+    local sandbox_profile="${1}"
+    local only_sandbox="${2}"
+    shift 2
+    local -a claude_args=("$@")
+
+    # Check if claude command is available
+    if ! command -v claude &>/dev/null; then
+      echo "Error: claude command not found" >&2
+      return 1
+    fi
+
+    # Check if sandbox profile exists
+    if [[ ! -f "$sandbox_profile" ]]; then
+      echo "Error: Sandbox profile not found: $sandbox_profile" >&2
+      return 1
+    fi
+
+    # Display execution info
+    if [[ "$only_sandbox" == "true" ]]; then
+      echo "Executing claude command in sandbox (without YOLO) with profile: $sandbox_profile"
+    else
+      echo "Executing claude command in sandbox with profile: $sandbox_profile"
+    fi
+    
+    # Execute claude with sandbox restrictions
+    if [[ "$only_sandbox" == "true" ]]; then
+      # Run with sandbox only (no YOLO flag)
+      sandbox-exec -f "$sandbox_profile" \
+        -D PWD="$(pwd)" \
+        -D HOME="$HOME" \
+        claude "${claude_args[@]}"
+    else
+      # Run with both sandbox and YOLO mode
+      sandbox-exec -f "$sandbox_profile" \
+        -D PWD="$(pwd)" \
+        -D HOME="$HOME" \
+        claude --dangerously-skip-permissions "${claude_args[@]}"
+    fi
+  }
+
+  # Default sandbox profile
+  local default_profile="$HOME/.zsh/claude/sandbox.sb"
+  local profile="$default_profile"
+  local only_sandbox="false"
+  local -a args=()
+
+  # Parse arguments
+  while [[ $# -gt 0 ]]; do
+    case "${1}" in
+      (-h|--help)
+        _ymt_claude_yolo_usage
+        return 0
+        ;;
+      (-p|--profile)
+        if [[ -z "${2}" ]]; then
+          echo "Error: --profile requires a path" >&2
+          return 1
+        fi
+        profile="${2}"
+        shift 2
+        ;;
+      (-os|--only-sandbox)
+        only_sandbox="true"
+        shift
+        ;;
+      (*)
+        args+=("${1}")
+        shift
+        ;;
+    esac
+  done
+
+  _ymt_claude_yolo_exec "$profile" "$only_sandbox" "${args[@]}"
 }
-
-_ymt_claude_yolo_exec() {
-  local sandbox_profile="${1}"
-  local only_sandbox="${2}"
-  shift 2
-  local -a claude_args=("$@")
-
-  # Check if claude command is available
-  if ! command -v claude &>/dev/null; then
-    echo "Error: claude command not found" >&2
-    return 1
-  fi
-
-  # Check if sandbox profile exists
-  if [[ ! -f "$sandbox_profile" ]]; then
-    echo "Error: Sandbox profile not found: $sandbox_profile" >&2
-    return 1
-  fi
-
-  # Display execution info
-  if [[ "$only_sandbox" == "true" ]]; then
-    echo "Executing claude command in sandbox (without YOLO) with profile: $sandbox_profile"
-  else
-    echo "Executing claude command in sandbox with profile: $sandbox_profile"
-  fi
-  
-  # Execute claude with sandbox restrictions
-  if [[ "$only_sandbox" == "true" ]]; then
-    # Run with sandbox only (no YOLO flag)
-    sandbox-exec -f "$sandbox_profile" \
-      -D PWD="$(pwd)" \
-      -D HOME="$HOME" \
-      claude "${claude_args[@]}"
-  else
-    # Run with both sandbox and YOLO mode
-    sandbox-exec -f "$sandbox_profile" \
-      -D PWD="$(pwd)" \
-      -D HOME="$HOME" \
-      claude --dangerously-skip-permissions "${claude_args[@]}"
-  fi
-}
-
-# Default sandbox profile
-local default_profile="$HOME/.zsh/claude/sandbox.sb"
-local profile="$default_profile"
-local only_sandbox="false"
-local -a args=()
-
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-  case "${1}" in
-    -h|--help)
-      _ymt_claude_yolo_usage
-      return 0
-      ;;
-    -p|--profile)
-      if [[ -z "${2}" ]]; then
-        echo "Error: --profile requires a path" >&2
-        return 1
-      fi
-      profile="${2}"
-      shift 2
-      ;;
-    --only-sandbox)
-      only_sandbox="true"
-      shift
-      ;;
-    -os)
-      only_sandbox="true"
-      shift
-      ;;
-    *)
-      args+=("${1}")
-      shift
-      ;;
-  esac
-done
-
-_ymt_claude_yolo_exec "$profile" "$only_sandbox" "${args[@]}"

--- a/.zsh/functions/claude-yolo
+++ b/.zsh/functions/claude-yolo
@@ -67,7 +67,7 @@ local -a args=()
 
 # Parse arguments
 while [[ $# -gt 0 ]]; do
-  case ${1} in
+  case "${1}" in
     -h|--help)
       _ymt_claude_yolo_usage
       return 0
@@ -80,7 +80,11 @@ while [[ $# -gt 0 ]]; do
       profile="${2}"
       shift 2
       ;;
-    -os|--only-sandbox)
+    --only-sandbox)
+      only_sandbox="true"
+      shift
+      ;;
+    -os)
       only_sandbox="true"
       shift
       ;;


### PR DESCRIPTION
## Summary
- claude-yoloコマンドに`--only-sandbox`（`-os`）オプションを追加
- このオプションを使用するとsandboxのみを適用し、YOLOモード（`--dangerously-skip-permissions`）なしでclaudeを実行可能

## Changes
- `--only-sandbox`/`-os`オプションの追加
- オプション使用時はYOLOフラグなしでsandbox-execを実行
- ヘルプメッセージの更新

## Test plan
- [ ] `claude-yolo --help`でヘルプメッセージが正しく表示される
- [ ] `claude-yolo --only-sandbox`でsandboxのみが適用される
- [ ] `claude-yolo -os`でショートオプションが動作する
- [ ] 通常の`claude-yolo`でYOLOモード＋sandboxが動作する

🤖 Generated with Claude Code