### PR TITLE
feat: claude-yoloコマンドに--only-sandboxオプションを追加

### DIFF
--- a/.zsh/functions/_claude-yolo
+++ b/.zsh/functions/_claude-yolo
@@ -7,6 +7,7 @@ _claude_yolo() {
   _arguments -C \
     '(-h --help)'{-h,--help}'[print help]' \
     '(-p --profile)'{-p,--profile}'[specify sandbox profile path]:profile file:_files' \
+    '(-os --only-sandbox)'{-os,--only-sandbox}'[run without --dangerously-skip-permissions]' \
     '*::claude args:->claude_args'
 
   case $state in

--- a/.zsh/functions/claude-yolo
+++ b/.zsh/functions/claude-yolo
@@ -9,6 +9,7 @@ Usage:
 
 Options:
     --profile, -p PATH     specify sandbox profile path
+    --only-sandbox, -os    run without --dangerously-skip-permissions
     --help, -h             print help
 
 Dependencies:
@@ -19,7 +20,8 @@ EOF
 
 _ymt_claude_yolo_exec() {
   local sandbox_profile="${1}"
-  shift
+  local only_sandbox="${2}"
+  shift 2
   local -a claude_args=("$@")
 
   # Check if claude command is available
@@ -36,17 +38,28 @@ _ymt_claude_yolo_exec() {
 
   # Display execution info
   echo "Executing claude command in sandbox with profile: $sandbox_profile"
+  if [[ "$only_sandbox" == "true" ]]; then
+    echo "Running without --dangerously-skip-permissions"
+  fi
   
   # Execute claude with sandbox restrictions
-  sandbox-exec -f "$sandbox_profile" \
-    -D PWD="$(pwd)" \
-    -D HOME="$HOME" \
-    claude --dangerously-skip-permissions "${claude_args[@]}"
+  if [[ "$only_sandbox" == "true" ]]; then
+    sandbox-exec -f "$sandbox_profile" \
+      -D PWD="$(pwd)" \
+      -D HOME="$HOME" \
+      claude "${claude_args[@]}"
+  else
+    sandbox-exec -f "$sandbox_profile" \
+      -D PWD="$(pwd)" \
+      -D HOME="$HOME" \
+      claude --dangerously-skip-permissions "${claude_args[@]}"
+  fi
 }
 
 # Default sandbox profile
 local default_profile="$HOME/.zsh/claude/sandbox.sb"
 local profile="$default_profile"
+local only_sandbox="false"
 local -a args=()
 
 # Parse arguments
@@ -64,6 +77,10 @@ while [[ $# -gt 0 ]]; do
       profile="${2}"
       shift 2
       ;;
+    -os|--only-sandbox)
+      only_sandbox="true"
+      shift
+      ;;
     *)
       args+=("${1}")
       shift
@@ -71,4 +88,4 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-_ymt_claude_yolo_exec "$profile" "${args[@]}"
+_ymt_claude_yolo_exec "$profile" "$only_sandbox" "${args[@]}"


### PR DESCRIPTION
## Summary
- `--only-sandbox` / `-os` オプションを追加して、`--dangerously-skip-permissions` を使わずに実行可能に
- zsh補完関数も同時に更新

## 変更内容
- `.zsh/functions/claude-yolo`: 新しいオプションの処理を追加
- `.zsh/functions/_claude-yolo`: 補完候補に新しいオプションを追加

## Test plan
- [x] `claude-yolo --help` でヘルプに新しいオプションが表示される
- [x] `claude-yolo -os` で `--dangerously-skip-permissions` なしで実行される
- [x] タブ補完で `-os` / `--only-sandbox` が候補に表示される

🤖 Generated with Claude Code