### PR TITLE
feat: uvパッケージを追加

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -153,6 +153,7 @@ if (( $+commands[go] )); then
 fi
 (( $+commands[kubectl] )) && source <(kubectl completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
+(( $+commands[uv] )) && eval "$(uv generate-shell-completion zsh 2>/dev/null)" 2>/dev/null
 # Use local claude installation if available
 [[ -x "$HOME/.claude/local/claude" ]] && alias claude="$HOME/.claude/local/claude"
 # Tiny prompt mode for screen recording

--- a/.zshrc.minimal
+++ b/.zshrc.minimal
@@ -104,6 +104,7 @@ if (( $+commands[go] )); then
 fi
 (( $+commands[kubectl] )) && source <(kubectl completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
+(( $+commands[uv] )) && eval "$(uv generate-shell-completion zsh 2>/dev/null)" 2>/dev/null
 # tealdeer: tldr client
 (( $+commands[tldr] )) && alias tldr="tldr --language=en"
 # Tiny prompt mode for screen recording

--- a/bin/homebrew/cli.sh
+++ b/bin/homebrew/cli.sh
@@ -38,6 +38,7 @@ brew install \
           tig \
           tmux \
           tree \
+          uv \
           wget \
           zsh \
           zsh-completions \


### PR DESCRIPTION
## Summary
- Homebrewのインストールパッケージにuvを追加
- zshの設定ファイルにuv補完機能を追加

## Changes
- `bin/homebrew/cli.sh`: uvをインストール対象に追加
- `.zshrc`, `.zshrc.minimal`: uvコマンドが存在する場合に補完を有効化

## Test plan
- [x] `brew install uv` でuvがインストールされることを確認
- [x] 新しいシェルセッションでuv補完が有効になることを確認

🤖 Generated with Claude Code