### PR TITLE
add opacity command for alacritty transparency

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -1,9 +1,6 @@
 [general]
 live_config_reload = true
-import = [
-  "~/.config/alacritty/opacity.toml",
-  "~/.config/alacritty/e2esound.toml"
-]
+import = ["~/.config/alacritty/e2esound.toml"]
 
 [bell]
 duration = 0

--- a/.config/alacritty/opacity.toml
+++ b/.config/alacritty/opacity.toml
@@ -1,2 +1,0 @@
-[window]
-opacity = 0.88

--- a/.zsh/functions/_opacity
+++ b/.zsh/functions/_opacity
@@ -1,0 +1,11 @@
+#compdef opacity
+local -a subcmds
+subcmds=('status:show current opacity value'\
+         'opaque:set opacity to 1.0 (fully opaque)'\
+         'high:set opacity to 0.95 (high opacity)'\
+         'clear:set opacity to 0.92 (default)'\
+         'medium:set opacity to 0.88 (medium opacity)'\
+         'low:set opacity to 0.83 (low opacity)'\
+         'transparent:set opacity to 0.75 (transparent)')
+_describe 'command' subcmds
+_alternative 'opacity:opacity value:(0.75 0.8 0.83 0.85 0.88 0.9 0.92 0.95 1.0)'

--- a/.zsh/functions/opacity
+++ b/.zsh/functions/opacity
@@ -1,0 +1,115 @@
+#!/bin/zsh
+
+if [[ $OSTYPE != 'darwin'* ]]; then
+  echo "Error: This command is only available on macOS" >&2
+  return 1
+fi
+
+readonly ALACRITTY_CONFIG="$HOME/.config/alacritty/alacritty.toml"
+
+_ymt_opacity_usage() {
+  cat <<EOF
+opacity is a command to change the opacity of Alacritty terminal.
+
+Usage:
+    opacity 0.9          set opacity to 0.9 (available: 0.0-1.0)
+    opacity status       print current opacity value
+    opacity opaque       set opacity to 1.0 (fully opaque)
+    opacity high         set opacity to 0.95 (high opacity)
+    opacity clear        set opacity to 0.92 (default)
+    opacity medium       set opacity to 0.88 (medium opacity)
+    opacity low          set opacity to 0.83 (low opacity)
+    opacity transparent  set opacity to 0.75 (transparent)
+
+Options:
+    --help, -h           print help
+
+Dependencies:
+    macOS, Alacritty
+EOF
+}
+
+_ymt_opacity_status() {
+  if [[ ! -f "$ALACRITTY_CONFIG" ]]; then
+    echo "Error: alacritty.toml not found at $ALACRITTY_CONFIG" >&2
+    return 1
+  fi
+
+  local current_opacity
+  if ! current_opacity=$(grep '^opacity = ' "$ALACRITTY_CONFIG" 2>/dev/null | awk '{print $3}'); then
+    echo "Error: Failed to read opacity value" >&2
+    return 1
+  fi
+
+  echo "Current opacity: $current_opacity"
+}
+
+_ymt_opacity_set() {
+  local value=$1
+
+  if [[ ! -f "$ALACRITTY_CONFIG" ]]; then
+    echo "Error: alacritty.toml not found at $ALACRITTY_CONFIG" >&2
+    return 1
+  fi
+
+  if ! sed -i.bak "s/^opacity = .*/opacity = $value/" "$ALACRITTY_CONFIG"; then
+    echo "Error: Failed to update opacity value" >&2
+    return 1
+  fi
+
+  # Remove backup file
+  rm -f "${ALACRITTY_CONFIG}.bak"
+
+  echo "Opacity set to $value"
+}
+
+case ${1} in
+  --help|-h)
+    _ymt_opacity_usage
+  ;;
+
+  status)
+    _ymt_opacity_status
+  ;;
+
+  opaque)
+    _ymt_opacity_set "1.0"
+  ;;
+
+  high)
+    _ymt_opacity_set "0.95"
+  ;;
+
+  clear)
+    _ymt_opacity_set "0.92"
+  ;;
+
+  medium)
+    _ymt_opacity_set "0.88"
+  ;;
+
+  low)
+    _ymt_opacity_set "0.83"
+  ;;
+
+  transparent)
+    _ymt_opacity_set "0.75"
+  ;;
+
+  *)
+    if [[ $1 =~ ^[01](\.[0-9]+)?$ ]]; then
+      local num_value=$(printf "%.2f" $1)
+      if (( $(echo "$num_value >= 0.0" | bc -l) )) && (( $(echo "$num_value <= 1.0" | bc -l) )); then
+        _ymt_opacity_set "$num_value"
+        _ymt_opacity_status
+      else
+        echo "Error: Value must be between 0.0 and 1.0" >&2
+        return 1
+      fi
+    else
+      echo "Error: Please specify a number between 0.0 and 1.0, or use a preset command." >&2
+      echo "Run 'opacity --help' for usage information." >&2
+      return 1
+    fi
+  ;;
+esac


### PR DESCRIPTION
## Summary
- alacrittyの透明度を動的に変更する`opacity`コマンドを追加
- プリセット: opaque, high, clear, medium, low, transparent
- メイン設定ファイルを直接編集することでlive reloadが動作

## Test plan
- [x] `opacity status`で現在値を確認
- [x] `opacity clear`でデフォルト値（0.92）に設定
- [x] 各プリセット（opaque, high, medium, low, transparent）を実行
- [x] 数値指定（`opacity 0.9`）が動作
- [x] タブ補完が動作

🤖 Generated with Claude Code