### PR TITLE
chore(nvim): fold 設定をデフォルト無効化に変更

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -107,7 +107,7 @@ opt.diffopt:append({ 'iwhite', 'horizontal' })
 -- ============================================================================
 
 if vim.fn.has('folding') == 1 then
-  opt.foldenable = true
+  opt.foldenable = false
   opt.foldmethod = 'indent'
   opt.fillchars = { vert = '|' }
 end

--- a/.vimrc
+++ b/.vimrc
@@ -187,7 +187,7 @@ augroup END
 
 " Folding settings
 if has('folding')
-  set foldenable
+  set nofoldenable
   set foldmethod=indent
   set fillchars=vert:\|
 

--- a/.vimrc.minimal
+++ b/.vimrc.minimal
@@ -66,7 +66,7 @@ augroup tabSetting
 augroup END
 
 if has('folding')
-  set foldenable
+  set nofoldenable
   set foldmethod=indent
   set fillchars=vert:\|
 endif


### PR DESCRIPTION
## Summary

- Neovim/Vim の fold 設定をデフォルトで無効化
- `zN` キーで必要な時のみ手動で有効化する方式に変更
- 短いファイルや fold が不要なファイルタイプで fold が邪魔になる問題を解決

## 変更内容

- `.config/nvim/lua/config/options.lua`: `foldenable = false` に変更
- `.vimrc` / `.vimrc.minimal`: `set nofoldenable` に変更
- Neovim の自動有効化ロジックを削除（完全に手動制御）

## Test plan

- [ ] Neovim で短いファイルを開き、デフォルトで fold が無効であることを確認
- [ ] `zN` を押して fold が有効化されることを確認
- [ ] `zn` を押して fold が無効化されることを確認
- [ ] Vim でも同様の動作を確認

🤖 Generated with Claude Code