### PR TITLE
fix(nvim): オプション設定と補完機能のロジックエラーを修正

### DIFF
--- a/.config/nvim/lua/config/options.lua
+++ b/.config/nvim/lua/config/options.lua
@@ -46,7 +46,7 @@ opt.formatoptions:append('mM')
 -- CLIPBOARD
 -- ============================================================================
 
-if jit.os == 'OSX' or jit.os == 'Windows' == 1 then
+if jit.os == 'OSX' or jit.os == 'Windows' then
   opt.clipboard:append('unnamed')
 end
 

--- a/.config/nvim/lua/plugins/completion.lua
+++ b/.config/nvim/lua/plugins/completion.lua
@@ -25,7 +25,14 @@ return {
       -- Helper function to check if there are words before cursor
       local has_words_before = function()
         local line, col = unpack(vim.api.nvim_win_get_cursor(0))
-        return col ~= 0 and vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]:sub(col, col):match('%s') == nil
+        if col == 0 then
+          return false
+        end
+        local line_content = vim.api.nvim_buf_get_lines(0, line - 1, line, true)[1]
+        if not line_content then
+          return false
+        end
+        return line_content:sub(col, col):match('%s') == nil
       end
 
       cmp.setup({


### PR DESCRIPTION
## 修正内容

### バグ1: options.lua の論理演算子エラー
- **行**: 49
- **問題**: Windows での clipboard 機能が動作しない
- **修正**: 不正な比較演算子を削除

### バグ2: completion.lua の nil アクセスエラー
- **行**: 25-29
- **問題**: 空バッファで補完機能がクラッシュ
- **修正**: nil チェックを追加

## テスト済み
- Neovim 起動確認
- 補完機能の動作確認
- エッジケース (空バッファ) の動作確認

🤖 Generated with Claude Code