### PR TITLE
feat(nvim): ~/.nvim_local.lua ローカル設定読み込み機能を追加

### DIFF
--- a/.config/nvim/init.lua
+++ b/.config/nvim/init.lua
@@ -8,3 +8,16 @@ require('config.lazy')         -- Bootstrap lazy.nvim plugin manager
 require('config.keymaps')      -- Keyboard shortcuts
 require('config.autocmds')     -- Autocommands
 
+-- ============================================================================
+-- LOCAL CONFIGURATION
+-- ============================================================================
+
+-- load ~/.nvim_local.lua if exists
+local local_config_path = vim.fn.expand('~/.nvim_local.lua')
+if vim.fn.filereadable(local_config_path) == 1 then
+  local ok, err = pcall(dofile, local_config_path)
+  if not ok then
+    vim.api.nvim_err_writeln('Error loading ~/.nvim_local.lua: ' .. err)
+  end
+end
+

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,6 +21,47 @@ Symbolic link を通じて各種ツールやアプリケーションの設定フ
 * 設定ファイルを変更した場合, そのツールの設定として問題ないか必ず確認してください。
     * 例えば `.zshrc` の場合 zsh 上で `source ~/.zshrc` を実行しエラーがないことを確認する必要があります。
 
+### ローカル設定ファイル
+
+マシン固有の設定や dotfiles リポジトリで管理したくない設定は, ローカル設定ファイルで管理できます。
+
+#### Vim
+
+`~/.vimrc_local` を作成すると, `.vimrc` の読み込み後に自動的に source されます。
+
+```vim
+" 例: マシン固有のキーマップ
+nnoremap <leader>local :echo "Local setting"<CR>
+```
+
+#### Neovim
+
+`~/.nvim_local.lua` を作成すると, `init.lua` の読み込み後に自動的に実行されます。
+
+```lua
+-- 例: オプションの上書き
+local opt = vim.opt
+opt.number = false
+
+-- 例: カスタムキーマップ
+local map = vim.keymap.set
+map('n', '<leader>local', ':echo "Local setting"<CR>', { noremap = true })
+
+-- 例: オートコマンド
+local autocmd = vim.api.nvim_create_autocmd
+autocmd('BufWritePre', {
+  pattern = '*.custom',
+  callback = function()
+    -- カスタム処理
+  end,
+})
+```
+
+**注意事項**:
+- これらのファイルはローカル環境専用であり, git 管理対象外です
+- `.nvim_local.lua` は Lua 構文で記述する必要があります (VimScript は使用できません)
+- プラグインの追加は lazy.nvim の仕組み上困難です (既存プラグインの設定上書きは可能)
+
 ## Git 運用ルール
 
 ### ブランチ運用


### PR DESCRIPTION
## Summary

- Neovim に `~/.nvim_local.lua` ローカル設定読み込み機能を追加
- `.vimrc` の `.vimrc_local` パターンと同様の仕組みを実現
- マシン固有の設定を dotfiles リポジトリの外で管理可能に

## Changes

- `.config/nvim/init.lua`: ローカル設定読み込みコードを追加
  - `pcall()` によるエラーハンドリングで安全性を確保
  - 全モジュール読み込み後に実行され、設定の上書きが可能
- `CLAUDE.md`: ローカル設定ファイルの使用方法をドキュメント化
  - Vim と Neovim 両方の使用例を追加
  - 注意事項を明記

## Test Results

すべてのテストケースが成功:
- ファイルが存在しない場合: 正常に起動 ✓
- 正常なファイルの場合: 設定が反映される ✓
- 構文エラーがある場合: エラーメッセージ表示だが起動する ✓
- 設定の上書き確認: 期待通りに動作 ✓

🤖 Generated with Claude Code