### PR TITLE
feat(zsh): Alacritty と Ghostty で異なる tmux セッションを起動

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -235,8 +235,12 @@ which less > /dev/null && source $HOME/.zsh/config/less.zsh
 [ -f $HOME/.zshrc_local ] && source $HOME/.zshrc_local
 
 # start tmux via tmx for Alacritty and Ghostty
-if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]] && [[ "$TERM" == alacritty* || "$TERM" == xterm-ghostty ]]; then
-  tmx
+if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]]; then
+  if [[ "$TERM" == alacritty* ]]; then
+    tmx
+  elif [[ "$TERM" == xterm-ghostty ]]; then
+    tmx ghostty
+  fi
 fi
 
 [ -n "$ZSH_PROFILE" ] && zprof | less


### PR DESCRIPTION
## Summary

- Alacritty では `tmx` を実行
- Ghostty では `tmx ghostty` を実行
- ターミナルごとに異なる tmux セッションを使用可能に

## Test plan

- [ ] Alacritty で起動時に `tmx` が呼び出されることを確認
- [ ] Ghostty で起動時に `tmx ghostty` が呼び出されることを確認
- [ ] 構文エラーがないことを確認済み

🤖 Generated with Claude Code