### PR TITLE
feat(hammerspoon): Ghostty/Alacritty を動的に検出するように変更

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -20,7 +20,7 @@ end
 
 -- Determine Terminal App (Ghostty or Alacritty)
 local terminalApp = "Alacritty"
-if application.pathForName and application.pathForName("Ghostty") then
+if hs.application.infoForBundleID("com.mitchellh.ghostty") ~= nil then
   terminalApp = "Ghostty"
 end
 


### PR DESCRIPTION
## 概要
Hammerspoon の設定を更新し、Ghostty がインストールされている場合は優先的に使用し、なければ Alacritty にフォールバックするよう動的に検出する機能を追加しました。

## 主な変更内容
- `hs.application.infoForBundleID` を使用したターミナルアプリの検出ロジックを追加
- Ghostty (`com.mitchellh.ghostty`) が利用可能な場合は優先的に使用
- Alacritty をデフォルトのフォールバックとして後方互換性を維持
- ターミナルトグルホットキー (Ctrl+Delete) が動的に決定されたアプリを使用

## 影響範囲
- Ghostty をインストール済みのユーザーは自動的に Ghostty が使用されます
- Alacritty を使用しているユーザーへの破壊的変更はありません
- ターミナルトグルの動作は一貫性を保ち、より賢いアプリ選択が行われます