### PR TITLE
feat(zsh): fz kill の検索・表示 UX を改善

### DIFF
--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -233,9 +233,46 @@ _ymt_fz_log() {
 # プロセスkill
 _ymt_fz_kill() {
   local pid
-  # 経過時間表示でプロセス一覧を表示
-  pid=$(LC_ALL=C ps -eo pid,user,pcpu,pmem,etime,comm | sed 1d | fzf -m \
-    --header "Select processes to kill (TAB: multi-select, Enter: kill)" | awk '{print $1}')
+  local list
+  list=$(LC_ALL=C ps -eo pid,user,pcpu,pmem,etime,args \
+    | awk 'NR>1 {
+        pid=$1; user=$2; cpu=$3; mem=$4; etime=$5
+        cmd=""
+        for (i=6; i<=NF; i++) cmd = cmd (i>6 ? " " : "") $i
+        split(cmd, parts, " ")
+        n = split(parts[1], segs, "/")
+        bname = segs[n]
+        if (bname == "") bname = parts[1]
+        printf "%-7s %-18.18s %5s %5s %14s  %-28.28s  %s\n", \
+          pid, user, cpu, mem, etime, bname, cmd
+      }')
+
+  local preview_cmd='pid=$(echo {} | awk "{print \$1}")
+if [ -n "$pid" ]; then
+  printf "\033[1;36m━━━━ Process ━━━━\033[0m\n"
+  ps -o pid,ppid,user,pcpu,pmem,etime,command -p "$pid" 2>/dev/null \
+    | awk "NR==1 { printf \"\\033[1;33m%-6s %-6s %-16s %5s %5s %14s  %s\\033[0m\\n\", \$1, \$2, \$3, \$4, \$5, \$6, \$7; next }
+           { cmd=\"\"; for (i=7; i<=NF; i++) cmd = cmd (i>7?\" \":\"\") \$i;
+             printf \"\\033[36m%-6s\\033[0m \\033[2m%-6s\\033[0m \\033[32m%-16s\\033[0m \\033[35m%5s\\033[0m \\033[35m%5s\\033[0m \\033[2m%14s\\033[0m  %s\\n\", \$1, \$2, \$3, \$4, \$5, \$6, cmd }"
+  echo
+  printf "\033[1;36m━━━━ Children ━━━━\033[0m\n"
+  children=$(pgrep -P "$pid" 2>/dev/null)
+  if [ -n "$children" ]; then
+    echo "$children" | tr "\n" " " | xargs ps -o pid,ppid,etime,command -p 2>/dev/null \
+      | awk "NR==1 { printf \"\\033[1;33m%-6s %-6s %14s  %s\\033[0m\\n\", \$1, \$2, \$3, \$4; next }
+             { cmd=\"\"; for (i=4; i<=NF; i++) cmd = cmd (i>4?\" \":\"\") \$i;
+               printf \"\\033[36m%-6s\\033[0m \\033[2m%-6s\\033[0m \\033[2m%14s\\033[0m  %s\\n\", \$1, \$2, \$3, cmd }"
+  else
+    printf "\033[2m(no children)\033[0m\n"
+  fi
+fi'
+
+  pid=$(echo "$list" | fzf -m \
+    --exact \
+    --header "Select processes to kill (TAB: multi, Enter: kill) | Search: substring + space=AND" \
+    --preview "$preview_cmd" \
+    --preview-window=down:40%:wrap \
+    | awk '{print $1}')
   if [ "x$pid" != "x" ]; then
     local signal=${1:-9}
     print -s "kill -$signal $pid"


### PR DESCRIPTION
## Summary

- `fz kill` を `--exact` モードに変更。スペースなしの入力は連続部分一致, スペース区切りは AND 検索となり, `pnp` で `Podcast`/`Photos` 等の無関係なプロセスがヒットしなくなる
- `ps` 出力を awk で整形し, コマンド列の先頭に basename を配置。長い絶対パスで切り詰められても実行ファイル名で識別できる
- fzf の preview ウィンドウ (下 40%) を追加。選択行の PID/PPID/USER/%CPU/%MEM/ETIME と子プロセス一覧をカラー表示

## 検索挙動の変更 (before / after)

| 入力 | 変更前 (fuzzy) | 変更後 (--exact) |
| :--- | :--- | :--- |
| `pnp` | `pnpm`, `Podcast`, `Photos`, ... | `pnpm` を含む行のみ |
| `node helper` | 文字がばらけてマッチ | `node` と `helper` の両方を部分文字列として含む行のみ |
| `'chrome` | extended-search 継続 | extended-search 継続 |

## Test plan

- [x] `zsh -n .zsh/functions/fz` で構文エラーなし
- [x] `ps -eo ... | awk ...` でリスト整形が意図通り (basename 列が先頭)
- [x] preview コマンドを単独で `sh -c` 実行し, ANSI color が出力されることを確認
- [ ] `source ~/.zshrc` 後, `fz kill` で以下を確認
  - [ ] 一覧に basename が先頭表示, ユーザー名列の崩れがない
  - [ ] `pnp` で `pnpm` 系のみヒット
  - [ ] `node helper` で両方を含む行のみ絞り込み
  - [ ] preview にカラー付きで Process/Children が表示される
  - [ ] TAB 複数選択 → Enter で選択したプロセスが kill される