### PR TITLE
feat(zsh): RPROMPT に AWS_PROFILE を表示

### DIFF
--- a/.zsh/config/zsh-git-prompt.sh
+++ b/.zsh/config/zsh-git-prompt.sh
@@ -13,5 +13,5 @@ ZSH_THEME_GIT_PROMPT_CLEAN="%{$fg[green]%}%{✔%G%}"
 # Set initial RPROMPT only if not already set
 # This allows prompt command settings to persist across sourcing
 if [[ -z "$RPROMPT" ]]; then
-  RPROMPT='$(git_super_status 2>/dev/null || echo "")${AWSUME_PROFILE:+[aws:$AWSUME_PROFILE]}'
+  RPROMPT='$(git_super_status 2>/dev/null || echo "")${AWSUME_PROFILE:+[awss:$AWSUME_PROFILE]}${AWS_PROFILE:+[awsp:$AWS_PROFILE]}'
 fi

--- a/.zsh/functions/prompt
+++ b/.zsh/functions/prompt
@@ -104,7 +104,7 @@ _ymt_prompt_right_status() {
 }
 
 _ymt_prompt_right_on() {
-  RPROMPT='$(git_super_status 2>/dev/null || echo "")${AWSUME_PROFILE:+[aws:$AWSUME_PROFILE]}'
+  RPROMPT='$(git_super_status 2>/dev/null || echo "")${AWSUME_PROFILE:+[awss:$AWSUME_PROFILE]}${AWS_PROFILE:+[awsp:$AWS_PROFILE]}'
   echo "Right prompt enabled"
 }
 


### PR DESCRIPTION
## Summary

- zsh の RPROMPT で `AWS_PROFILE` が設定されているときにもプロファイル名を表示するようにした
- `awsume` 由来の `AWSUME_PROFILE` と区別するため, ラベルを以下のように変更:
  - `AWSUME_PROFILE` → `[awss:<profile>]`
  - `AWS_PROFILE` → `[awsp:<profile>]`
- 両方設定されている場合はラベルで識別できる形で両方表示される (例: `[awss:foo][awsp:foo]`)

対象ファイル:

- `.zsh/config/zsh-git-prompt.sh`
- `.zsh/functions/prompt` (`_ymt_prompt_right_on`)

## Test plan

- [x] `zsh -n` による構文チェック
- [x] 展開確認 (いずれも未設定 / AWSUME_PROFILE のみ / AWS_PROFILE のみ / 両方)
- [ ] 新規 zsh セッションで RPROMPT が期待通り表示されるか手元で確認
- [ ] `prompt right off` → `prompt right on` のトグルで新 RPROMPT が反映されるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)