### PR TITLE
feat(zsh): aws-sso 関数と fz aws-sso サブコマンドを追加

### DIFF
--- a/.zsh/functions/_aws-sso
+++ b/.zsh/functions/_aws-sso
@@ -1,0 +1,44 @@
+#compdef aws-sso
+
+_aws_sso() {
+  local context state line
+  typeset -A opt_args
+
+  _arguments -C \
+    '(-h --help)'{-h,--help}'[print help]' \
+    '1: :_aws_sso_subcommands' \
+    '*::arg:->args'
+
+  case $state in
+    args)
+      case $line[1] in
+        login)
+          _arguments '1: :_aws_sso_profiles'
+          ;;
+        unset)
+          ;;
+      esac
+      ;;
+  esac
+}
+
+_aws_sso_subcommands() {
+  local -a subcommands
+  subcommands=(
+    'login:SSO ログイン + AWS_PROFILE を export'
+    'unset:AWS_PROFILE を unset'
+    'list:SSO profile を TSV で出力'
+  )
+  _describe -t subcommands 'aws-sso subcommand' subcommands
+}
+
+_aws_sso_profiles() {
+  local -a profiles
+  local name
+  while IFS=$'\t' read -r name _ _ _; do
+    [[ -n "$name" ]] && profiles+=("$name")
+  done < <(aws-sso list 2>/dev/null)
+  _describe -t profiles 'SSO profile' profiles
+}
+
+_aws_sso "$@"

--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -71,19 +71,19 @@ _fz() {
 _fz_subcommands() {
   local -a subcommands
   subcommands=(
+    'aws-sso:AWS SSO profile を選択してログイン'
     'branch:Git branch切り替え'
-    'log:Git commit履歴検索（batでシンタックスハイライト）'
-    'kill:プロセス検索・kill'
-    'docker:Docker container接続'
-    'history:コマンド履歴検索・実行'
-    'env:環境変数検索・表示'
     'cd:ディレクトリ履歴から移動（fdで拡張検索）'
-    'pr:GitHub Pull Request一覧'
-    'issue:GitHub Issue一覧'
+    'docker:Docker container接続'
+    'env:環境変数検索・表示'
     'find:ファイル検索（fdを使用）'
+    'history:コマンド履歴検索・実行'
+    'issue:GitHub Issue一覧'
+    'kill:プロセス検索・kill'
+    'log:Git commit履歴検索（batでシンタックスハイライト）'
+    'pr:GitHub Pull Request一覧'
     'vi:ファイルをnvimで開く（fdを使用）'
     'vim:ファイルをnvimで開く（fdを使用）'
-    'aws-sso:AWS SSO profile を選択してログイン'
   )
   _describe -t subcommands 'fz subcommand' subcommands
 }

--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -59,6 +59,10 @@ _fz() {
           _arguments \
             '(-h --help)'{-h,--help}'[Show help]'
           ;;
+        aws-sso)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Show help]'
+          ;;
       esac
       ;;
   esac
@@ -79,6 +83,7 @@ _fz_subcommands() {
     'find:ファイル検索（fdを使用）'
     'vi:ファイルをnvimで開く（fdを使用）'
     'vim:ファイルをnvimで開く（fdを使用）'
+    'aws-sso:AWS SSO profile を選択してログイン'
   )
   _describe -t subcommands 'fz subcommand' subcommands
 }

--- a/.zsh/functions/aws-sso
+++ b/.zsh/functions/aws-sso
@@ -1,0 +1,135 @@
+#!/bin/zsh
+
+_ymt_aws_sso_usage() {
+  cat <<EOF
+aws-sso helps login to AWS via IAM Identity Center (SSO) and manage AWS_PROFILE.
+
+Usage:
+    aws-sso login <profile>   SSO ログインを実行し AWS_PROFILE を export
+    aws-sso unset             AWS_PROFILE を unset
+    aws-sso list              ~/.aws/config の SSO profile を TSV で出力
+    aws-sso -h, --help        ヘルプを表示
+
+Description:
+    login は aws sso login --profile <profile> を実行し,
+    成功した場合のみ AWS_PROFILE=<profile> を export します.
+    <profile> は ~/.aws/config の SSO profile のみ指定可能です.
+
+Dependencies:
+    aws CLI
+EOF
+}
+
+# ~/.aws/config から SSO profile のみを抽出する.
+# 出力形式: "<profile>\t<sso_account_id>\t<sso_role_name>\t<region>"
+# 値が無い項目は "-" を出力する.
+#
+# Security: ~/.aws/credentials は意図的に参照しない. config の読み取りキーも
+# sso_session / sso_start_url / sso_account_id / sso_role_name / region に限定し,
+# aws_access_key_id などの機密情報は一切拾わない.
+_ymt_aws_sso_list_profiles() {
+  local config="${AWS_CONFIG_FILE:-$HOME/.aws/config}"
+  if [ ! -r "$config" ]; then
+    echo "Error: AWS config file not found: $config" >&2
+    return 1
+  fi
+
+  awk '
+    function flush() {
+      if (in_profile && is_sso) {
+        printf "%s\t%s\t%s\t%s\n",
+          name,
+          (account == "" ? "-" : account),
+          (role == "" ? "-" : role),
+          (region == "" ? "-" : region)
+      }
+      in_profile = 0
+      is_sso = 0
+      name = ""; account = ""; role = ""; region = ""
+    }
+    /^[[:space:]]*\[/ {
+      flush()
+      line = $0
+      sub(/^[[:space:]]*\[/, "", line)
+      sub(/\][[:space:]]*$/, "", line)
+      if (line ~ /^profile[[:space:]]+/) {
+        sub(/^profile[[:space:]]+/, "", line)
+        name = line
+        in_profile = 1
+      }
+      next
+    }
+    in_profile {
+      if ($0 ~ /^[[:space:]]*#/) next
+      eq = index($0, "=")
+      if (eq == 0) next
+      key = substr($0, 1, eq - 1)
+      val = substr($0, eq + 1)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+      gsub(/^[[:space:]]+|[[:space:]]+$/, "", val)
+      if (key == "sso_session" || key == "sso_start_url") is_sso = 1
+      else if (key == "sso_account_id") account = val
+      else if (key == "sso_role_name") role = val
+      else if (key == "region") region = val
+    }
+    END { flush() }
+  ' "$config"
+}
+
+_ymt_aws_sso_login() {
+  local profile="$1"
+  if [ -z "$profile" ]; then
+    _ymt_aws_sso_usage >&2
+    return 1
+  fi
+
+  if ! aws sso login --profile "$profile"; then
+    echo "Error: aws sso login failed for profile '$profile'" >&2
+    return 1
+  fi
+
+  export AWS_PROFILE="$profile"
+  print -s "export AWS_PROFILE=$profile"
+  echo "AWS_PROFILE=$profile"
+}
+
+_ymt_aws_sso_unset() {
+  unset AWS_PROFILE
+  print -s "unset AWS_PROFILE"
+  echo "AWS_PROFILE unset"
+}
+
+if ! (( $+commands[aws] )); then
+  echo "Error: aws CLI not found. Please install awscli." >&2
+  return 1
+fi
+
+case ${1} in
+  -h|--help)
+    _ymt_aws_sso_usage
+  ;;
+
+  login)
+    shift
+    _ymt_aws_sso_login "$@"
+  ;;
+
+  unset)
+    _ymt_aws_sso_unset
+  ;;
+
+  list)
+    _ymt_aws_sso_list_profiles
+  ;;
+
+  "")
+    _ymt_aws_sso_usage >&2
+    return 1
+  ;;
+
+  *)
+    echo "Error: Unknown subcommand '$1'" >&2
+    echo "Run 'aws-sso --help' for usage." >&2
+    return 1
+  ;;
+esac

--- a/.zsh/functions/aws-sso
+++ b/.zsh/functions/aws-sso
@@ -83,6 +83,15 @@ _ymt_aws_sso_login() {
     return 1
   fi
 
+  # ~/.aws/config にある SSO profile のみ許可する.
+  # aws-sso list の結果 (TSV) の先頭フィールドと照合し, 未登録 profile は拒否.
+  if ! _ymt_aws_sso_list_profiles | awk -F'\t' -v p="$profile" '$1 == p { found = 1 } END { exit !found }'; then
+    echo "Error: '$profile' is not an SSO profile in ~/.aws/config" >&2
+    echo "Available SSO profiles:" >&2
+    _ymt_aws_sso_list_profiles | awk -F'\t' '{ print "  " $1 }' >&2
+    return 1
+  fi
+
   if ! aws sso login --profile "$profile"; then
     echo "Error: aws sso login failed for profile '$profile'" >&2
     return 1

--- a/.zsh/functions/aws-sso
+++ b/.zsh/functions/aws-sso
@@ -98,7 +98,7 @@ _ymt_aws_sso_login() {
   fi
 
   export AWS_PROFILE="$profile"
-  print -s "export AWS_PROFILE=$profile"
+  print -s "export AWS_PROFILE=${(q)profile}"
   echo "AWS_PROFILE=$profile"
 }
 

--- a/.zsh/functions/aws-sso
+++ b/.zsh/functions/aws-sso
@@ -83,6 +83,13 @@ _ymt_aws_sso_login() {
     return 1
   fi
 
+  # aws CLI 必須チェックは login のみ. list/unset は config 読み取りと
+  # 環境変数操作しかしないため CLI 未導入でも動かしたい.
+  if ! (( $+commands[aws] )); then
+    echo "Error: aws CLI not found. Please install awscli." >&2
+    return 1
+  fi
+
   # ~/.aws/config にある SSO profile のみ許可する.
   # aws-sso list の結果 (TSV) の先頭フィールドと照合し, 未登録 profile は拒否.
   if ! _ymt_aws_sso_list_profiles | awk -F'\t' -v p="$profile" '$1 == p { found = 1 } END { exit !found }'; then
@@ -107,11 +114,6 @@ _ymt_aws_sso_unset() {
   print -s "unset AWS_PROFILE"
   echo "AWS_PROFILE unset"
 }
-
-if ! (( $+commands[aws] )); then
-  echo "Error: aws CLI not found. Please install awscli." >&2
-  return 1
-fi
 
 case ${1} in
   -h|--help)

--- a/.zsh/functions/aws-sso
+++ b/.zsh/functions/aws-sso
@@ -2,20 +2,20 @@
 
 _ymt_aws_sso_usage() {
   cat <<EOF
-aws-sso helps login to AWS via IAM Identity Center (SSO) and manage AWS_PROFILE.
+aws-sso は IAM Identity Center (SSO) 経由の AWS ログインと AWS_PROFILE の管理を行います.
 
-Usage:
+使い方:
     aws-sso login <profile>   SSO ログインを実行し AWS_PROFILE を export
     aws-sso unset             AWS_PROFILE を unset
     aws-sso list              ~/.aws/config の SSO profile を TSV で出力
     aws-sso -h, --help        ヘルプを表示
 
-Description:
+説明:
     login は aws sso login --profile <profile> を実行し,
     成功した場合のみ AWS_PROFILE=<profile> を export します.
     <profile> は ~/.aws/config の SSO profile のみ指定可能です.
 
-Dependencies:
+依存関係:
     aws CLI
 EOF
 }

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -710,7 +710,7 @@ _ymt_fz_aws_sso() {
   # タブ区切りで保持する. fzf は --with-nth 1 で整形列のみを表示するが, 選択後の profile 取得は
   # TSV フィールドから行うため空白を含む profile 名でも壊れない.
   local joined
-  joined=$(echo "$profiles" | awk -F'\t' '{
+  joined=$(printf '%s\n' "$profiles" | awk -F'\t' '{
     formatted = sprintf("%-28s %-14s %-30s %s", $1, $2, $3, $4)
     printf "%s\t%s\t%s\t%s\t%s\n", formatted, $1, $2, $3, $4
   }')

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -91,6 +91,10 @@ _ymt_fz_check_dependencies() {
     missing_deps+=("pgrep")
   fi
 
+  if [[ "$subcommand" == "aws-sso" ]] && ! (( $+commands[aws] )); then
+    missing_deps+=("aws")
+  fi
+
   if [[ "$subcommand" == "lazygit" ]]; then
     if ! (( $+commands[lazygit] )); then
       missing_deps+=("lazygit")
@@ -152,6 +156,7 @@ Subcommands:
   lazygit   Git リポジトリを検索して lazygit で開く
   find      ファイル検索（fdを使用）
   vi/vim    ファイルをnvimで開く（fdを使用）
+  aws-sso   AWS SSO profile を選択してログイン
 
 Examples:
   fz branch     # Git branchを選択して切り替え
@@ -168,6 +173,7 @@ Examples:
   fz find       # ファイルを検索して選択
   fz vi         # ファイルを検索してnvimで開く
   fz vim        # ファイルを検索してnvimで開く
+  fz aws-sso    # AWS SSO profile を選択してログイン
 EOF
 }
 
@@ -687,6 +693,54 @@ _ymt_fz_view() {
   fi
 }
 
+# AWS SSO profile 選択ログイン
+_ymt_fz_aws_sso() {
+  local profiles
+  profiles=$(aws-sso list) || return 1
+
+  if [ -z "$profiles" ]; then
+    echo "No SSO profiles found in ~/.aws/config" >&2
+    return 1
+  fi
+
+  local header
+  header=$(printf "%-28s %-14s %-30s %s" "PROFILE" "ACCOUNT_ID" "ROLE" "REGION")
+
+  local formatted
+  formatted=$(echo "$profiles" | awk -F'\t' '{ printf "%-28s %-14s %-30s %s\n", $1, $2, $3, $4 }')
+
+  # preview は aws-sso list が返した whitelist 済み TSV 行のみを参照する.
+  # credentials (access_key/secret_key) は読み取らない.
+  local preview_cmd
+  preview_cmd='echo {} | awk "{
+    printf \"Profile:    %s\n\", \$1
+    printf \"Account ID: %s\n\", \$2
+    printf \"Role:       %s\n\", \$3
+    printf \"Region:     %s\n\", \$4
+    printf \"Command:    aws sso login --profile %s\n\", \$1
+  }"'
+
+  local selected
+  selected=$(echo "$formatted" | fzf \
+    --header "$header" \
+    --header-lines=0 \
+    --preview "$preview_cmd" \
+    --preview-window=down:7:wrap \
+    --reverse)
+
+  if [ -z "$selected" ]; then
+    return 0
+  fi
+
+  local profile
+  profile=$(echo "$selected" | awk '{print $1}')
+  if [ -z "$profile" ]; then
+    return 1
+  fi
+
+  aws-sso login "$profile"
+}
+
 # 依存関係をチェック
 if ! _ymt_fz_check_dependencies "$1" 2>/dev/null; then
   _ymt_fz_check_dependencies "$1"
@@ -746,6 +800,10 @@ case "${1:-help}" in
   vi|vim)
     shift
     _ymt_fz_view "$@"
+    ;;
+  aws-sso)
+    shift
+    _ymt_fz_aws_sso "$@"
     ;;
   --help|-h)
     _ymt_fz_usage

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -718,7 +718,7 @@ _ymt_fz_aws_sso() {
   # preview は aws-sso list が返した whitelist 済み TSV 行のみを参照する.
   # credentials (access_key/secret_key) は読み取らない.
   local preview_cmd
-  preview_cmd='echo {} | awk -F"\t" "{
+  preview_cmd='printf "%s\n" {} | awk -F"\t" "{
     printf \"Profile:    %s\n\", \$2
     printf \"Account ID: %s\n\", \$3
     printf \"Role:       %s\n\", \$4

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -706,22 +706,30 @@ _ymt_fz_aws_sso() {
   local header
   header=$(printf "%-28s %-14s %-30s %s" "PROFILE" "ACCOUNT_ID" "ROLE" "REGION")
 
-  local formatted
-  formatted=$(echo "$profiles" | awk -F'\t' '{ printf "%-28s %-14s %-30s %s\n", $1, $2, $3, $4 }')
+  # 先頭フィールドに整形済み表示列, 続いて TSV の元フィールド (profile/account/role/region) を
+  # タブ区切りで保持する. fzf は --with-nth 1 で整形列のみを表示するが, 選択後の profile 取得は
+  # TSV フィールドから行うため空白を含む profile 名でも壊れない.
+  local joined
+  joined=$(echo "$profiles" | awk -F'\t' '{
+    formatted = sprintf("%-28s %-14s %-30s %s", $1, $2, $3, $4)
+    printf "%s\t%s\t%s\t%s\t%s\n", formatted, $1, $2, $3, $4
+  }')
 
   # preview は aws-sso list が返した whitelist 済み TSV 行のみを参照する.
   # credentials (access_key/secret_key) は読み取らない.
   local preview_cmd
-  preview_cmd='echo {} | awk "{
-    printf \"Profile:    %s\n\", \$1
-    printf \"Account ID: %s\n\", \$2
-    printf \"Role:       %s\n\", \$3
-    printf \"Region:     %s\n\", \$4
-    printf \"Command:    aws sso login --profile %s\n\", \$1
+  preview_cmd='echo {} | awk -F"\t" "{
+    printf \"Profile:    %s\n\", \$2
+    printf \"Account ID: %s\n\", \$3
+    printf \"Role:       %s\n\", \$4
+    printf \"Region:     %s\n\", \$5
+    printf \"Command:    aws sso login --profile %s\n\", \$2
   }"'
 
   local selected
-  selected=$(echo "$formatted" | fzf \
+  selected=$(echo "$joined" | fzf \
+    --delimiter $'\t' \
+    --with-nth 1 \
     --header "$header" \
     --header-lines=0 \
     --preview "$preview_cmd" \
@@ -733,7 +741,7 @@ _ymt_fz_aws_sso() {
   fi
 
   local profile
-  profile=$(echo "$selected" | awk '{print $1}')
+  profile=$(echo "$selected" | awk -F'\t' '{print $2}')
   if [ -z "$profile" ]; then
     return 1
   fi

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -143,37 +143,37 @@ fz - fzf wrapper command
 Usage: fz <subcommand> [options]
 
 Subcommands:
+  aws-sso   AWS SSO profile を選択してログイン
   branch    Git branch切り替え
-  log       Git commit履歴検索（batでシンタックスハイライト）
-  kill      プロセス検索・kill
+  cd        ディレクトリ履歴から移動（fdで拡張検索）
   devkill   dev サーバプロセス (pnpm/npm/vite/next 等) を検索して子孫ごと kill
   docker    Docker container接続
-  history   コマンド履歴検索・実行
   env       環境変数検索・表示
-  cd        ディレクトリ履歴から移動（fdで拡張検索）
-  pr        GitHub Pull Request一覧
-  issue     GitHub Issue一覧
-  lazygit   Git リポジトリを検索して lazygit で開く
   find      ファイル検索（fdを使用）
+  history   コマンド履歴検索・実行
+  issue     GitHub Issue一覧
+  kill      プロセス検索・kill
+  lazygit   Git リポジトリを検索して lazygit で開く
+  log       Git commit履歴検索（batでシンタックスハイライト）
+  pr        GitHub Pull Request一覧
   vi/vim    ファイルをnvimで開く（fdを使用）
-  aws-sso   AWS SSO profile を選択してログイン
 
 Examples:
+  fz aws-sso    # AWS SSO profile を選択してログイン
   fz branch     # Git branchを選択して切り替え
-  fz log        # Git logを検索（Ctrl+Yでhash copy）
-  fz kill       # プロセスを選択してkill
+  fz cd         # ディレクトリ履歴から選択して移動
   fz devkill    # 開発サーバを選択して子孫プロセスごとkill
   fz docker     # Docker containerを選択して接続
-  fz history    # コマンド履歴を検索して実行
   fz env        # 環境変数を検索・表示
-  fz cd         # ディレクトリ履歴から選択して移動
-  fz pr         # Pull Requestを選択して詳細表示
-  fz issue      # Issueを選択して詳細表示
-  fz lazygit    # Git リポジトリを検索して lazygit で開く
   fz find       # ファイルを検索して選択
+  fz history    # コマンド履歴を検索して実行
+  fz issue      # Issueを選択して詳細表示
+  fz kill       # プロセスを選択してkill
+  fz lazygit    # Git リポジトリを検索して lazygit で開く
+  fz log        # Git logを検索（Ctrl+Yでhash copy）
+  fz pr         # Pull Requestを選択して詳細表示
   fz vi         # ファイルを検索してnvimで開く
   fz vim        # ファイルを検索してnvimで開く
-  fz aws-sso    # AWS SSO profile を選択してログイン
 EOF
 }
 

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -65,7 +65,9 @@ _ymt_fz_check_dependencies() {
     missing_deps+=("fzf")
   fi
 
-  if ! (( $+commands[git] )); then
+  # git は git を直接使うサブコマンドのみ必須. aws-sso など git と無関係の
+  # サブコマンドまで git 未導入で弾かないようにする.
+  if [[ "$subcommand" != "aws-sso" ]] && ! (( $+commands[git] )); then
     missing_deps+=("git")
   fi
 


### PR DESCRIPTION
## Summary
AWS SSO ログイン時の操作を簡略化するため, `aws-sso` 関数と `fz aws-sso` サブコマンドを追加しました. SSO profile の選択からログイン, `AWS_PROFILE` の export までを一連の操作で完結させます.

## Key Changes
- `.zsh/functions/aws-sso` (新規): `login` / `unset` / `list` サブコマンドを持つ独立関数を追加
  - `login <profile>`: `aws sso login --profile <profile>` を実行し, 成功時のみ `AWS_PROFILE` を export
  - `unset`: `AWS_PROFILE` を unset
  - `list`: `~/.aws/config` から SSO profile のみを TSV で出力
- `.zsh/functions/_aws-sso` (新規): サブコマンド補完と `login` の profile 補完を追加
- `.zsh/functions/fz` / `.zsh/functions/_fz`: `fz aws-sso` サブコマンドを追加. `aws-sso list` の出力を fzf で選択し, 内部で `aws-sso login` を呼ぶ
- `fz` の help とサブコマンド補完配列を alphabet 順に整列

## Impact
- **セキュリティ**: `~/.aws/credentials` や `access_key` / `secret_key` は一切参照しない. `~/.aws/config` 側も `sso_session` / `sso_start_url` / `sso_account_id` / `sso_role_name` / `region` のみを whitelist で読み取る
- **空白を含む profile 名**: `fz aws-sso` 内部で TSV を保持しタブ区切りで抽出するため, `my team` のような空白を含む profile 名でも壊れない
- **RPROMPT 表示**: 既存の `${AWS_PROFILE:+[awsp:$AWS_PROFILE]}` 設定 (`.zsh/config/zsh-git-prompt.sh`) により, login 後は `[awsp:<profile>]` が自動表示される

## Test plan
- [ ] `source ~/.zshrc` 後に `aws-sso -h` / `aws-sso list` が期待通り動作する
- [ ] `aws-sso login <profile>` 後に `echo $AWS_PROFILE` が設定されている
- [ ] `aws-sso unset` 後に `AWS_PROFILE` が解除される
- [ ] `fz aws-sso` で SSO profile のみが fzf に表示される
- [ ] 非 SSO profile (`default`, `administrator` 等) が一覧に含まれない
- [ ] `fz aws<TAB>` / `aws-sso <TAB>` の補完が動作する
- [ ] preview に Profile/Account ID/Role/Region/Command が表示される
