### PR TITLE
feat(via): Q11 のマクロに continue と質問用文言を追加

### DIFF
--- a/via/keychron_q11_ansi_knob.layout.json
+++ b/via/keychron_q11_ansi_knob.layout.json
@@ -1,7 +1,24 @@
 {
   "name": "Keychron Q11 ANSI Knob",
   "vendorProductId": 875823584,
-  "macros": ["", "", "", "", "", "", "", "", "", "", "", "", "", "", "", ""],
+  "macros": [
+    "",
+    "continue",
+    "what's doing now?",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    "",
+    ""
+  ],
   "layers": [
     [
       "RGB_TOG",


### PR DESCRIPTION
## Summary

Keychron Q11 ANSI Knob のマクロスロットに, コーディングエージェント等への定型入力としてよく使う 2 つのテキストを登録します。VIA で書き込み済みのレイアウトを dotfiles 側にも反映させ, 環境再構築時にすぐ復元できるようにすることが目的です。

## Key Changes

- `via/keychron_q11_ansi_knob.layout.json`
  - `macros[1]` に `continue` を追加
  - `macros[2]` に `what's doing now?` を追加
  - 既存の空マクロ枠 (合計 16) は維持
  - 配列を 1 行から複数行表記に変更し, 差分の可読性を改善

## Impact

- VIA でこのレイアウト JSON を読み込む場合, 該当キーに上記マクロが上書きされる点に注意してください。
- キーマップ (`layers`) は変更していないため, マクロを割り当てたキーが無ければ動作面の影響はありません。
- 他のキーボード設定ファイルには影響しません。
