### PR TITLE
feat(zsh): fz skills サブコマンドを追加

### DIFF
--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -63,6 +63,11 @@ _fz() {
           _arguments \
             '(-h --help)'{-h,--help}'[Show help]'
           ;;
+        skills)
+          _arguments \
+            '(-h --help)'{-h,--help}'[Show help]' \
+            '1::skill name:_fz_skill_names'
+          ;;
       esac
       ;;
   esac
@@ -82,10 +87,28 @@ _fz_subcommands() {
     'kill:プロセス検索・kill'
     'log:Git commit履歴検索（batでシンタックスハイライト）'
     'pr:GitHub Pull Request一覧'
+    'skills:Skill (SKILL.md + 関連ファイル) を mo でブラウザ表示'
     'vi:ファイルをnvimで開く（fdを使用）'
     'vim:ファイルをnvimで開く（fdを使用）'
   )
   _describe -t subcommands 'fz subcommand' subcommands
+}
+
+# fz skills 用の skill 名補完
+_fz_skill_names() {
+  local -a names
+  local r d
+  for r in "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.copilot/skills" "$HOME/.gemini/skills" "$HOME/.agents/skills"; do
+    [[ -d $r ]] || continue
+    for d in $r/*(/N); do
+      [[ -L $d ]] && continue
+      [[ -f $d/SKILL.md ]] || continue
+      names+=("${d:t}")
+    done
+  done
+  # 重複除去
+  names=(${(u)names})
+  _describe -t skills 'skill name' names
 }
 
 # git log のオプション補完（簡易版）

--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -95,20 +95,38 @@ _fz_subcommands() {
 }
 
 # fz skills 用の skill 名補完
+# 本体 (_ymt_fz_skills_list) と同じく、basename が複数 host にまたがる場合のみ
+# 候補を <host>/<basename> 表記に変える
 _fz_skill_names() {
-  local -a names
-  local r d
+  local r d host name
+  local -A counts
+  local -a entries
   for r in "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.copilot/skills" "$HOME/.gemini/skills" "$HOME/.agents/skills"; do
     [[ -d $r ]] || continue
+    host="${${r:h}:t}"
+    host="${host#.}"
     for d in $r/*(/N); do
       [[ -L $d ]] && continue
       [[ -f $d/SKILL.md ]] || continue
-      names+=("${d:t}")
+      name="${d:t}"
+      entries+=("$host"$'\t'"$name")
+      (( counts[$name]++ ))
     done
   done
-  # 重複除去
-  names=(${(u)names})
-  _describe -t skills 'skill name' names
+
+  local -a candidates
+  local entry
+  local -a parts
+  for entry in "${entries[@]}"; do
+    parts=("${(@s:	:)entry}")
+    if (( counts[${parts[2]}] > 1 )); then
+      candidates+=("${parts[1]}/${parts[2]}")
+    else
+      candidates+=("${parts[2]}")
+    fi
+  done
+  candidates=(${(u)candidates})
+  _describe -t skills 'skill name' candidates
 }
 
 # git log のオプション補完（簡易版）

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -792,11 +792,7 @@ _ymt_fz_skills() {
     target=$(printf '%s' "$match" | cut -f3)
   else
     local selected preview_cmd
-    if (( $+commands[bat] )); then
-      preview_cmd='path=$(printf "%s" {} | cut -f3); bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"'
-    else
-      preview_cmd='path=$(printf "%s" {} | cut -f3); head -80 -- "$path/SKILL.md"'
-    fi
+    preview_cmd='path=$(printf "%s" {} | cut -f3); if command -v bat >/dev/null 2>&1; then bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"; else head -80 -- "$path/SKILL.md"; fi'
 
     selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -791,11 +791,20 @@ _ymt_fz_skills() {
     name=$(printf '%s' "$match" | cut -f2)
     target=$(printf '%s' "$match" | cut -f3)
   else
-    # fzf preview は zsh -c で実行され, .zshrc を読まないため PATH が
-    # /usr/bin だけ等の貧弱な状態になることがある (bat も /bin/cat も
-    # 見つからないケースがある). main shell の PATH を引き継いで実行する.
+    # fzf preview は zsh -c (subshell) で実行されるため .zshrc を読まず,
+    # PATH が貧弱な状態になり bat / cat / cut が見つからないケースがある.
+    # main shell 側で各コマンドを絶対パスに解決して preview に埋め込む.
+    local cut_bin="${commands[cut]:-/usr/bin/cut}"
+    local cat_bin="${commands[cat]:-/bin/cat}"
+    local viewer
+    if [[ -n ${commands[bat]} ]]; then
+      viewer="${commands[bat]} --style=full --color=always --"
+    else
+      viewer="$cat_bin --"
+    fi
+
     local selected preview_cmd
-    preview_cmd="export PATH=${(q)PATH}; "'path=$(printf "%s" {} | cut -f3); if (( $+commands[bat] )); then bat --style=full --color=always -- "$path/SKILL.md"; else cat -- "$path/SKILL.md"; fi'
+    preview_cmd="path=\$(printf '%s' {} | $cut_bin -f3); $viewer \"\$path/SKILL.md\""
 
     selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -791,8 +791,20 @@ _ymt_fz_skills() {
     name=$(printf '%s' "$match" | cut -f2)
     target=$(printf '%s' "$match" | cut -f3)
   else
+    # fzf preview は non-interactive subshell で実行され $PATH が
+    # 引き継がれないことがある (Homebrew /opt/homebrew/bin など). ここで
+    # 絶対パスを解決して preview コマンドに埋め込む.
+    local cut_bin="${commands[cut]:-/usr/bin/cut}"
+    local cat_bin="${commands[cat]:-/bin/cat}"
+    local viewer
+    if [[ -n ${commands[bat]} ]]; then
+      viewer="${commands[bat]} --style=plain --color=always --line-range=:80 --"
+    else
+      viewer="$cat_bin --"
+    fi
+
     local selected preview_cmd
-    preview_cmd='path=$(printf "%s" {} | cut -f3); if command -v bat >/dev/null 2>&1; then bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"; else head -80 -- "$path/SKILL.md"; fi'
+    preview_cmd="path=\$(printf '%s' {} | $cut_bin -f3); $viewer \"\$path/SKILL.md\""
 
     selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -792,11 +792,7 @@ _ymt_fz_skills() {
     target=$(printf '%s' "$match" | cut -f3)
   else
     local selected preview_cmd
-    if (( $+commands[bat] )); then
-      preview_cmd='path=$(printf "%s" {} | cut -f3); bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"'
-    else
-      preview_cmd='path=$(printf "%s" {} | cut -f3); head -80 -- "$path/SKILL.md"'
-    fi
+    preview_cmd='path=$(printf "%s" {} | cut -f3); if (( $+commands[bat] )); then bat --style=full --color=always -- "$path/SKILL.md"; else cat -- "$path/SKILL.md"; fi'
 
     selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -791,20 +791,12 @@ _ymt_fz_skills() {
     name=$(printf '%s' "$match" | cut -f2)
     target=$(printf '%s' "$match" | cut -f3)
   else
-    # fzf preview は non-interactive subshell で実行され $PATH が
-    # 引き継がれないことがある (Homebrew /opt/homebrew/bin など). ここで
-    # 絶対パスを解決して preview コマンドに埋め込む.
-    local cut_bin="${commands[cut]:-/usr/bin/cut}"
-    local cat_bin="${commands[cat]:-/bin/cat}"
-    local viewer
-    if [[ -n ${commands[bat]} ]]; then
-      viewer="${commands[bat]} --style=plain --color=always --line-range=:80 --"
-    else
-      viewer="$cat_bin --"
-    fi
-
     local selected preview_cmd
-    preview_cmd="path=\$(printf '%s' {} | $cut_bin -f3); $viewer \"\$path/SKILL.md\""
+    if (( $+commands[bat] )); then
+      preview_cmd='path=$(printf "%s" {} | cut -f3); bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"'
+    else
+      preview_cmd='path=$(printf "%s" {} | cut -f3); head -80 -- "$path/SKILL.md"'
+    fi
 
     selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -777,9 +777,27 @@ _ymt_fz_skills() {
       echo "Error: skill 名が空です" >&2
       return 1
     fi
-    # list の display ($1) または basename ($2) と完全一致する行を探す
+    # 1) display ($1) との完全一致を優先 (host/name 指定もここで解決)
     local match
-    match=$(printf '%s\n' "$list" | awk -F'\t' -v q="$input" '$1 == q || $2 == q {print; exit}')
+    match=$(printf '%s\n' "$list" | awk -F'\t' -v q="$input" '$1 == q {print; exit}')
+    if [[ -z $match ]]; then
+      # 2) basename ($2) との一致にフォールバック. 複数 host に同名がある場合は
+      #    曖昧なので拒否し host 指定を要求する.
+      local basename_rows
+      basename_rows=$(printf '%s\n' "$list" | awk -F'\t' -v q="$input" '$2 == q')
+      if [[ -n $basename_rows ]]; then
+        local row_count
+        row_count=$(printf '%s\n' "$basename_rows" | wc -l | tr -d ' ')
+        if (( row_count > 1 )); then
+          {
+            echo "Error: skill '$input' は複数の host に存在し曖昧です。host を含めて指定してください:"
+            printf '%s\n' "$basename_rows" | cut -f1 | sed 's/^/  - /'
+          } >&2
+          return 1
+        fi
+        match="$basename_rows"
+      fi
+    fi
     if [[ -z $match ]]; then
       {
         echo "Error: skill '$input' が見つかりません"

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -791,8 +791,11 @@ _ymt_fz_skills() {
     name=$(printf '%s' "$match" | cut -f2)
     target=$(printf '%s' "$match" | cut -f3)
   else
+    # fzf preview は zsh -c で実行され, .zshrc を読まないため PATH が
+    # /usr/bin だけ等の貧弱な状態になることがある (bat も /bin/cat も
+    # 見つからないケースがある). main shell の PATH を引き継いで実行する.
     local selected preview_cmd
-    preview_cmd='path=$(printf "%s" {} | cut -f3); if (( $+commands[bat] )); then bat --style=full --color=always -- "$path/SKILL.md"; else cat -- "$path/SKILL.md"; fi'
+    preview_cmd="export PATH=${(q)PATH}; "'path=$(printf "%s" {} | cut -f3); if (( $+commands[bat] )); then bat --style=full --color=always -- "$path/SKILL.md"; else cat -- "$path/SKILL.md"; fi'
 
     selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -97,6 +97,10 @@ _ymt_fz_check_dependencies() {
     missing_deps+=("aws")
   fi
 
+  if [[ "$subcommand" == "skills" ]] && ! (( $+commands[mo] )); then
+    missing_deps+=("mo (brew install k1LoW/tap/mo)")
+  fi
+
   if [[ "$subcommand" == "lazygit" ]]; then
     if ! (( $+commands[lazygit] )); then
       missing_deps+=("lazygit")
@@ -158,6 +162,7 @@ Subcommands:
   lazygit   Git リポジトリを検索して lazygit で開く
   log       Git commit履歴検索（batでシンタックスハイライト）
   pr        GitHub Pull Request一覧
+  skills    Skill (SKILL.md + 関連ファイル) を mo でブラウザ表示
   vi/vim    ファイルをnvimで開く（fdを使用）
 
 Examples:
@@ -174,6 +179,7 @@ Examples:
   fz lazygit    # Git リポジトリを検索して lazygit で開く
   fz log        # Git logを検索（Ctrl+Yでhash copy）
   fz pr         # Pull Requestを選択して詳細表示
+  fz skills     # Skill 一覧から選んで mo でブラウザプレビュー
   fz vi         # ファイルを検索してnvimで開く
   fz vim        # ファイルを検索してnvimで開く
 EOF
@@ -695,6 +701,124 @@ _ymt_fz_view() {
   fi
 }
 
+# Skill (SKILL.md + 関連ファイル) を mo でブラウザ表示
+# 5 root を共通配列で公開する関数 (autoload 関数内で typeset -g 経由でグローバル化)
+_ymt_fz_skill_roots() {
+  print -l \
+    "$HOME/.claude/skills" \
+    "$HOME/.codex/skills" \
+    "$HOME/.copilot/skills" \
+    "$HOME/.gemini/skills" \
+    "$HOME/.agents/skills"
+}
+
+# 引数で渡された skill 名を 5 root から順に解決し、最初に見つかった
+# 「symlink でない & SKILL.md を持つ」ディレクトリの絶対パスを stdout に出す
+_ymt_fz_skills_resolve() {
+  local name="$1" r target
+  for r in $(_ymt_fz_skill_roots); do
+    target="$r/$name"
+    [[ -L $target ]] && continue
+    [[ -d $target && -f $target/SKILL.md ]] || continue
+    echo "$target"
+    return 0
+  done
+  return 1
+}
+
+# 5 root から symlink でなく SKILL.md を持つ skill ディレクトリを列挙
+# 出力は "<name>\t<full path>"。basename 重複時は先勝ち。
+_ymt_fz_skills_list() {
+  local r d
+  for r in $(_ymt_fz_skill_roots); do
+    [[ -d $r ]] || continue
+    for d in $r/*(/N); do
+      [[ -L $d ]] && continue
+      [[ -f $d/SKILL.md ]] || continue
+      printf '%s\t%s\n' "${d:t}" "$d"
+    done
+  done | awk -F'\t' '!seen[$1]++' | LC_ALL=C sort
+}
+
+_ymt_fz_skills() {
+  local name target
+
+  if [[ $# -gt 1 ]]; then
+    echo "Error: skill 名は 1 つだけ指定してください (received: $#)" >&2
+    return 1
+  fi
+
+  if [[ $# -eq 1 ]]; then
+    name="$1"
+    case "$name" in
+      */*)
+        echo "Error: パス指定は受け付けません。skill 名のみ指定してください (例: pr-create)" >&2
+        return 1
+        ;;
+      "")
+        echo "Error: skill 名が空です" >&2
+        return 1
+        ;;
+    esac
+    if ! target=$(_ymt_fz_skills_resolve "$name"); then
+      {
+        echo "Error: skill '$name' が見つかりません"
+        echo "探索 root:"
+        _ymt_fz_skill_roots | sed 's/^/  - /'
+      } >&2
+      return 1
+    fi
+  else
+    local list selected
+    list=$(_ymt_fz_skills_list)
+    if [[ -z $list ]]; then
+      {
+        echo "Error: 表示可能な skill がありません"
+        echo "探索 root:"
+        _ymt_fz_skill_roots | sed 's/^/  - /'
+      } >&2
+      return 1
+    fi
+
+    local preview_cmd
+    if (( $+commands[bat] )); then
+      preview_cmd='path=$(printf "%s" {} | cut -f2); bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"'
+    else
+      preview_cmd='path=$(printf "%s" {} | cut -f2); head -80 -- "$path/SKILL.md"'
+    fi
+
+    selected=$(echo "$list" | fzf \
+      --delimiter $'\t' \
+      --with-nth=1 \
+      --preview "$preview_cmd" \
+      --preview-window=right:60%:wrap \
+      --header "Select skill to preview with mo")
+
+    [[ -z $selected ]] && return 0
+
+    name=$(printf '%s' "$selected" | cut -f1)
+    target=$(printf '%s' "$selected" | cut -f2)
+  fi
+
+  local files
+  files=$(find -L "$target" -type f \( \
+    -name '*.md' -o -name '*.sh' -o -name '*.json' -o \
+    -name '*.yaml' -o -name '*.yml' -o -name '*.txt' -o \
+    -name '*.py' -o -name '*.ts' -o -name '*.js' \
+    \) | LC_ALL=C sort)
+
+  if [[ -z $files ]]; then
+    echo "Error: '$target' に表示可能なテキストファイルがありません" >&2
+    return 1
+  fi
+
+  local -a file_args
+  file_args=("${(@f)files}")
+
+  print -s "mo --target $name ${file_args[*]}"
+  mo --target "$name" "${file_args[@]}"
+}
+
 # AWS SSO profile 選択ログイン
 _ymt_fz_aws_sso() {
   local profiles
@@ -814,6 +938,10 @@ case "${1:-help}" in
   aws-sso)
     shift
     _ymt_fz_aws_sso "$@"
+    ;;
+  skills)
+    shift
+    _ymt_fz_skills "$@"
     ;;
   --help|-h)
     _ymt_fz_usage

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -752,6 +752,38 @@ _ymt_fz_skills_list() {
   done | LC_ALL=C sort
 }
 
+# stdin に <display>\t<basename>\t<path> 形式の行を受け取り fzf で 1 行を
+# 選ばせて選択行をそのまま stdout に出す. 第 1 引数は fzf header 文字列.
+# preview は SKILL.md の YAML frontmatter (--- ... ---) のみを抽出して
+# 表示する (本文は確認の用を成さないため切り捨て).
+# fzf preview は zsh -c (subshell) で実行されるため .zshrc を読まず,
+# PATH が貧弱で bat / cat / cut が見つからないケースがある. main shell 側で
+# 各コマンドを絶対パスに解決して preview に埋め込む.
+_ymt_fz_skills_pick() {
+  local header="$1"
+  local cut_bin="${commands[cut]:-/usr/bin/cut}"
+  local cat_bin="${commands[cat]:-/bin/cat}"
+  local awk_bin="${commands[awk]:-/usr/bin/awk}"
+  local viewer
+  if [[ -n ${commands[bat]} ]]; then
+    viewer="${commands[bat]} --language yaml --color=always --style=plain"
+  else
+    viewer="$cat_bin"
+  fi
+
+  # awk script: 1 つ目の `---` 以降, 2 つ目の `---` までを emit
+  local awk_script='/^---$/{c++; next} c==1'
+  local preview_cmd
+  preview_cmd="path=\$(printf '%s' {} | $cut_bin -f3); $awk_bin '$awk_script' \"\$path/SKILL.md\" | $viewer"
+
+  fzf \
+    --delimiter $'\t' \
+    --with-nth=1 \
+    --preview "$preview_cmd" \
+    --preview-window=right:50%:wrap \
+    --header "$header"
+}
+
 _ymt_fz_skills() {
   local name target
 
@@ -771,6 +803,7 @@ _ymt_fz_skills() {
     return 1
   fi
 
+  local match
   if [[ $# -eq 1 ]]; then
     local input="$1"
     if [[ -z $input ]]; then
@@ -778,24 +811,21 @@ _ymt_fz_skills() {
       return 1
     fi
     # 1) display ($1) との完全一致を優先 (host/name 指定もここで解決)
-    local match
     match=$(printf '%s\n' "$list" | awk -F'\t' -v q="$input" '$1 == q {print; exit}')
     if [[ -z $match ]]; then
-      # 2) basename ($2) との一致にフォールバック. 複数 host に同名がある場合は
-      #    曖昧なので拒否し host 指定を要求する.
+      # 2) basename ($2) との一致. 複数 host にまたがる場合は候補を fzf に
+      #    流して選ばせる (一覧経路と同じ UX).
       local basename_rows
       basename_rows=$(printf '%s\n' "$list" | awk -F'\t' -v q="$input" '$2 == q')
       if [[ -n $basename_rows ]]; then
         local row_count
         row_count=$(printf '%s\n' "$basename_rows" | wc -l | tr -d ' ')
         if (( row_count > 1 )); then
-          {
-            echo "Error: skill '$input' は複数の host に存在し曖昧です。host を含めて指定してください:"
-            printf '%s\n' "$basename_rows" | cut -f1 | sed 's/^/  - /'
-          } >&2
-          return 1
+          match=$(printf '%s\n' "$basename_rows" | _ymt_fz_skills_pick "Pick skill: '$input' は複数 host に存在")
+          [[ -z $match ]] && return 0
+        else
+          match="$basename_rows"
         fi
-        match="$basename_rows"
       fi
     fi
     if [[ -z $match ]]; then
@@ -806,36 +836,13 @@ _ymt_fz_skills() {
       } >&2
       return 1
     fi
-    name=$(printf '%s' "$match" | cut -f2)
-    target=$(printf '%s' "$match" | cut -f3)
   else
-    # fzf preview は zsh -c (subshell) で実行されるため .zshrc を読まず,
-    # PATH が貧弱な状態になり bat / cat / cut が見つからないケースがある.
-    # main shell 側で各コマンドを絶対パスに解決して preview に埋め込む.
-    local cut_bin="${commands[cut]:-/usr/bin/cut}"
-    local cat_bin="${commands[cat]:-/bin/cat}"
-    local viewer
-    if [[ -n ${commands[bat]} ]]; then
-      viewer="${commands[bat]} --style=full --color=always --"
-    else
-      viewer="$cat_bin --"
-    fi
-
-    local selected preview_cmd
-    preview_cmd="path=\$(printf '%s' {} | $cut_bin -f3); $viewer \"\$path/SKILL.md\""
-
-    selected=$(printf '%s\n' "$list" | fzf \
-      --delimiter $'\t' \
-      --with-nth=1 \
-      --preview "$preview_cmd" \
-      --preview-window=right:60%:wrap \
-      --header "Select skill to preview with mo")
-
-    [[ -z $selected ]] && return 0
-
-    name=$(printf '%s' "$selected" | cut -f2)
-    target=$(printf '%s' "$selected" | cut -f3)
+    match=$(printf '%s\n' "$list" | _ymt_fz_skills_pick "Select skill to preview with mo")
+    [[ -z $match ]] && return 0
   fi
+
+  name=$(printf '%s' "$match" | cut -f2)
+  target=$(printf '%s' "$match" | cut -f3)
 
   local files
   files=$(find -L "$target" -type f \( \

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -712,32 +712,44 @@ _ymt_fz_skill_roots() {
     "$HOME/.agents/skills"
 }
 
-# 引数で渡された skill 名を 5 root から順に解決し、最初に見つかった
-# 「symlink でない & SKILL.md を持つ」ディレクトリの絶対パスを stdout に出す
-_ymt_fz_skills_resolve() {
-  local name="$1" r target
-  for r in $(_ymt_fz_skill_roots); do
-    target="$r/$name"
-    [[ -L $target ]] && continue
-    [[ -d $target && -f $target/SKILL.md ]] || continue
-    echo "$target"
-    return 0
-  done
-  return 1
+# root path から host 名 (claude / codex / copilot / gemini / agents) を取り出す
+_ymt_fz_skills_host_of_root() {
+  local host="${${1:h}:t}"
+  echo "${host#.}"
 }
 
 # 5 root から symlink でなく SKILL.md を持つ skill ディレクトリを列挙
-# 出力は "<name>\t<full path>"。basename 重複時は先勝ち。
+# 出力は "<display>\t<basename>\t<full path>"
+# basename が複数 host にまたがる場合のみ display を "<host>/<basename>" に変える
 _ymt_fz_skills_list() {
-  local r d
+  local r d host name
+  local -A counts
+  local -a entries
   for r in $(_ymt_fz_skill_roots); do
     [[ -d $r ]] || continue
+    host=$(_ymt_fz_skills_host_of_root "$r")
     for d in $r/*(/N); do
       [[ -L $d ]] && continue
       [[ -f $d/SKILL.md ]] || continue
-      printf '%s\t%s\n' "${d:t}" "$d"
+      name="${d:t}"
+      entries+=("$host"$'\t'"$name"$'\t'"$d")
+      (( counts[$name]++ ))
     done
-  done | awk -F'\t' '!seen[$1]++' | LC_ALL=C sort
+  done
+
+  local entry display
+  local -a parts
+  for entry in "${entries[@]}"; do
+    parts=("${(@s:	:)entry}")
+    host="${parts[1]}"
+    name="${parts[2]}"
+    if (( counts[$name] > 1 )); then
+      display="$host/$name"
+    else
+      display="$name"
+    fi
+    printf '%s\t%s\t%s\n' "$display" "$name" "${parts[3]}"
+  done | LC_ALL=C sort
 }
 
 _ymt_fz_skills() {
@@ -748,46 +760,45 @@ _ymt_fz_skills() {
     return 1
   fi
 
+  local list
+  list=$(_ymt_fz_skills_list)
+  if [[ -z $list ]]; then
+    {
+      echo "Error: 表示可能な skill がありません"
+      echo "探索 root:"
+      _ymt_fz_skill_roots | sed 's/^/  - /'
+    } >&2
+    return 1
+  fi
+
   if [[ $# -eq 1 ]]; then
-    name="$1"
-    case "$name" in
-      */*)
-        echo "Error: パス指定は受け付けません。skill 名のみ指定してください (例: pr-create)" >&2
-        return 1
-        ;;
-      "")
-        echo "Error: skill 名が空です" >&2
-        return 1
-        ;;
-    esac
-    if ! target=$(_ymt_fz_skills_resolve "$name"); then
+    local input="$1"
+    if [[ -z $input ]]; then
+      echo "Error: skill 名が空です" >&2
+      return 1
+    fi
+    # list の display ($1) または basename ($2) と完全一致する行を探す
+    local match
+    match=$(printf '%s\n' "$list" | awk -F'\t' -v q="$input" '$1 == q || $2 == q {print; exit}')
+    if [[ -z $match ]]; then
       {
-        echo "Error: skill '$name' が見つかりません"
-        echo "探索 root:"
-        _ymt_fz_skill_roots | sed 's/^/  - /'
+        echo "Error: skill '$input' が見つかりません"
+        echo "利用可能な skill 名:"
+        printf '%s\n' "$list" | cut -f1 | sed 's/^/  - /'
       } >&2
       return 1
     fi
+    name=$(printf '%s' "$match" | cut -f2)
+    target=$(printf '%s' "$match" | cut -f3)
   else
-    local list selected
-    list=$(_ymt_fz_skills_list)
-    if [[ -z $list ]]; then
-      {
-        echo "Error: 表示可能な skill がありません"
-        echo "探索 root:"
-        _ymt_fz_skill_roots | sed 's/^/  - /'
-      } >&2
-      return 1
-    fi
-
-    local preview_cmd
+    local selected preview_cmd
     if (( $+commands[bat] )); then
-      preview_cmd='path=$(printf "%s" {} | cut -f2); bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"'
+      preview_cmd='path=$(printf "%s" {} | cut -f3); bat --style=plain --color=always --line-range=:80 -- "$path/SKILL.md"'
     else
-      preview_cmd='path=$(printf "%s" {} | cut -f2); head -80 -- "$path/SKILL.md"'
+      preview_cmd='path=$(printf "%s" {} | cut -f3); head -80 -- "$path/SKILL.md"'
     fi
 
-    selected=$(echo "$list" | fzf \
+    selected=$(printf '%s\n' "$list" | fzf \
       --delimiter $'\t' \
       --with-nth=1 \
       --preview "$preview_cmd" \
@@ -796,8 +807,8 @@ _ymt_fz_skills() {
 
     [[ -z $selected ]] && return 0
 
-    name=$(printf '%s' "$selected" | cut -f1)
-    target=$(printf '%s' "$selected" | cut -f2)
+    name=$(printf '%s' "$selected" | cut -f2)
+    target=$(printf '%s' "$selected" | cut -f3)
   fi
 
   local files


### PR DESCRIPTION
## Summary

- `coding-agents/agents/skills/skill-preview/bin/skill-preview.sh` の処理を `.zsh/functions/fz` に移植し、`fz skills [<name>]` で SKILL.md と関連ファイルを `mo` に渡してブラウザ表示できるようにした
- 走査対象は `~/.{claude,codex,copilot,gemini,agents}/skills/` の 5 root。各 root 直下の subdir のうち **symlink ではなく SKILL.md を持つ** ものだけを skill として扱う (`~/.agents/skills/_shared` のような補助は自動除外)
- 一覧生成ロジックを `_ymt_fz_skills_list` に一本化し、引数指定時もその結果に対する完全一致検索で resolve。basename が複数 host にまたがる場合のみ表示を `<host>/<name>` 形式に切り替え

## Test plan

- [x] `zsh -n .zsh/functions/fz` / `zsh -n .zsh/functions/_fz` で構文エラーなし
- [x] `fz --help` の Subcommands に `skills` が表示される
- [x] `_ymt_fz_skills_list` が `~/.agents/skills/` 配下の実体 17 件を返し、`_shared` (SKILL.md なし) が除外されている
- [x] `fz skills pr-create` が `~/.agents/skills/pr-create` を解決する (claude/copilot 側の symlink は skip)
- [x] `fz skills nonexistent` で「見つかりません」+ 利用可能 skill 一覧が出る
- [x] `fz skills foo/bar` も同様に「見つからない」扱いで安全に弾かれる
- [ ] 実機で `fz skills` を引数なし起動して fzf ピッカーから skill を選び、`mo` がブラウザを開いて SKILL.md がレンダリングされること
- [ ] `fz skills <Tab>` で補完候補に skill 名が出ること
- [ ] `mo` 不在時に `brew install k1LoW/tap/mo` の案内が出ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)