### PR TITLE
feat(main_machine): add google gemini to homebrew cask list

### DIFF
--- a/bin/homebrew/main_machine.sh
+++ b/bin/homebrew/main_machine.sh
@@ -10,6 +10,7 @@ brew install --cask \
           appcleaner \
           aqua-voice \
           deskpad \
+          google-gemini \
           ghostty \
           keycastr \
           zoom


### PR DESCRIPTION
## Summary
- メインマシン用 Homebrew cask リストに `google-gemini` を追加し, `make setup` 時に Google Gemini デスクトップアプリが自動インストールされるようにする。

## Key Changes
- `bin/homebrew/main_machine.sh`: `--cask` の対象一覧に `google-gemini` を 1 行追加 (アルファベット順位置)。

## Impact
- 副作用は cask 1 つ増えるのみ。既存ツールへの影響なし。
- セットアップ済み環境では `make setup` 再実行時に新規インストールされる。
