### PR TITLE
feat(zsh): fz skills が現在の git repo 直下の skill も探索するよう拡張

### DIFF
--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -97,14 +97,41 @@ _fz_subcommands() {
 # fz skills 用の skill 名補完
 # 本体 (_ymt_fz_skills_list) と同じく、basename が複数 host にまたがる場合のみ
 # 候補を <host>/<basename> 表記に変える
+# 探索 root は $HOME 直下に加え, 現在の git リポジトリ root 直下も対象
+# (リポジトリ由来は host を "repo:<host>" として区別する)
 _fz_skill_names() {
   local r d host name
   local -A counts
-  local -a entries
-  for r in "$HOME/.claude/skills" "$HOME/.codex/skills" "$HOME/.copilot/skills" "$HOME/.gemini/skills" "$HOME/.agents/skills"; do
+  local -a entries roots
+
+  roots=(
+    "$HOME/.claude/skills"
+    "$HOME/.codex/skills"
+    "$HOME/.copilot/skills"
+    "$HOME/.gemini/skills"
+    "$HOME/.agents/skills"
+  )
+
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -n $repo_root && $repo_root != $HOME ]]; then
+    roots+=(
+      "$repo_root/.claude/skills"
+      "$repo_root/.codex/skills"
+      "$repo_root/.copilot/skills"
+      "$repo_root/.gemini/skills"
+      "$repo_root/.agents/skills"
+    )
+  fi
+
+  for r in "${roots[@]}"; do
     [[ -d $r ]] || continue
     host="${${r:h}:t}"
     host="${host#.}"
+    case "$r" in
+      "$HOME/.claude/skills"|"$HOME/.codex/skills"|"$HOME/.copilot/skills"|"$HOME/.gemini/skills"|"$HOME/.agents/skills") ;;
+      *) host="repo:$host" ;;
+    esac
     for d in $r/*(/N); do
       [[ -L $d ]] && continue
       [[ -f $d/SKILL.md ]] || continue

--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -130,7 +130,7 @@ _fz_skill_names() {
     host="${host#.}"
     case "$r" in
       "$HOME/.claude/skills"|"$HOME/.codex/skills"|"$HOME/.copilot/skills"|"$HOME/.gemini/skills"|"$HOME/.agents/skills") ;;
-      *) host="repo:$host" ;;
+      *) host="${${r:h:h}:t}:$host" ;;
     esac
     for d in $r/*(/N); do
       [[ -L $d ]] && continue

--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -98,7 +98,7 @@ _fz_subcommands() {
 # 本体 (_ymt_fz_skills_list) と同じく、basename が複数 host にまたがる場合のみ
 # 候補を <host>/<basename> 表記に変える
 # 探索 root は $HOME 直下に加え, 現在の git リポジトリ root 直下も対象
-# (リポジトリ由来は host を "repo:<host>" として区別する)
+# (リポジトリ由来は host を "<repo-name>:<host>" として区別する)
 _fz_skill_names() {
   local r d host name
   local -A counts

--- a/.zsh/functions/_fz
+++ b/.zsh/functions/_fz
@@ -142,12 +142,15 @@ _fz_skill_names() {
   done
 
   local -a candidates
-  local entry
+  local entry cand
   local -a parts
   for entry in "${entries[@]}"; do
     parts=("${(@s:	:)entry}")
     if (( counts[${parts[2]}] > 1 )); then
-      candidates+=("${parts[1]}/${parts[2]}")
+      # _describe は ":" を「候補:説明」の区切りとして解釈するため,
+      # repo 名や host を含む候補に現れる ":" は backslash でエスケープする
+      cand="${parts[1]}/${parts[2]}"
+      candidates+=("${cand//:/\\:}")
     else
       candidates+=("${parts[2]}")
     fi

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -702,20 +702,46 @@ _ymt_fz_view() {
 }
 
 # Skill (SKILL.md + 関連ファイル) を mo でブラウザ表示
-# 5 root を共通配列で公開する関数 (autoload 関数内で typeset -g 経由でグローバル化)
+# $HOME 直下と現在の git リポジトリ root 直下の skill ディレクトリ群を公開する
+# (autoload 関数内で typeset -g 経由でグローバル化)
 _ymt_fz_skill_roots() {
-  print -l \
-    "$HOME/.claude/skills" \
-    "$HOME/.codex/skills" \
-    "$HOME/.copilot/skills" \
-    "$HOME/.gemini/skills" \
+  local -a roots
+  roots=(
+    "$HOME/.claude/skills"
+    "$HOME/.codex/skills"
+    "$HOME/.copilot/skills"
+    "$HOME/.gemini/skills"
     "$HOME/.agents/skills"
+  )
+
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -n $repo_root && $repo_root != $HOME ]]; then
+    roots+=(
+      "$repo_root/.claude/skills"
+      "$repo_root/.codex/skills"
+      "$repo_root/.copilot/skills"
+      "$repo_root/.gemini/skills"
+      "$repo_root/.agents/skills"
+    )
+  fi
+
+  print -l -- "${roots[@]}"
 }
 
 # root path から host 名 (claude / codex / copilot / gemini / agents) を取り出す
+# $HOME 直下の root はそのまま, それ以外 (リポジトリ root 直下) は "repo:<host>"
+# として $HOME 側と区別する
 _ymt_fz_skills_host_of_root() {
-  local host="${${1:h}:t}"
-  echo "${host#.}"
+  local root="$1"
+  local host="${${root:h}:t}"
+  host="${host#.}"
+  case "$root" in
+    "$HOME/.claude/skills"|"$HOME/.codex/skills"|"$HOME/.copilot/skills"|"$HOME/.gemini/skills"|"$HOME/.agents/skills")
+      echo "$host" ;;
+    *)
+      echo "repo:$host" ;;
+  esac
 }
 
 # 5 root から symlink でなく SKILL.md を持つ skill ディレクトリを列挙

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -702,8 +702,8 @@ _ymt_fz_view() {
 }
 
 # Skill (SKILL.md + 関連ファイル) を mo でブラウザ表示
-# $HOME 直下と現在の git リポジトリ root 直下の skill ディレクトリ群を公開する
-# (autoload 関数内で typeset -g 経由でグローバル化)
+# $HOME 直下と現在の git リポジトリ root 直下の skill ディレクトリ群を列挙する
+# roots は標準出力 (print -l) で返す
 _ymt_fz_skill_roots() {
   local -a roots
   roots=(

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -730,8 +730,9 @@ _ymt_fz_skill_roots() {
 }
 
 # root path から host 名 (claude / codex / copilot / gemini / agents) を取り出す
-# $HOME 直下の root はそのまま, それ以外 (リポジトリ root 直下) は "repo:<host>"
-# として $HOME 側と区別する
+# $HOME 直下の root はそのまま, それ以外 (リポジトリ root 直下) は
+# "<repo-name>:<host>" としてどの repo の skill か分かる形で返す
+# (root は "<repo-root>/.<host>/skills" 構造なので :h:h:t で repo 名が取れる)
 _ymt_fz_skills_host_of_root() {
   local root="$1"
   local host="${${root:h}:t}"
@@ -740,7 +741,8 @@ _ymt_fz_skills_host_of_root() {
     "$HOME/.claude/skills"|"$HOME/.codex/skills"|"$HOME/.copilot/skills"|"$HOME/.gemini/skills"|"$HOME/.agents/skills")
       echo "$host" ;;
     *)
-      echo "repo:$host" ;;
+      local repo_name="${${root:h:h}:t}"
+      echo "$repo_name:$host" ;;
   esac
 }
 

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -752,8 +752,10 @@ _ymt_fz_skills_host_of_root() {
 _ymt_fz_skills_list() {
   local r d host name
   local -A counts
-  local -a entries
-  for r in $(_ymt_fz_skill_roots); do
+  local -a entries roots
+  roots=("${(@f)$(_ymt_fz_skill_roots)}")
+  for r in "${roots[@]}"; do
+    [[ -z $r ]] && continue
     [[ -d $r ]] || continue
     host=$(_ymt_fz_skills_host_of_root "$r")
     for d in $r/*(/N); do


### PR DESCRIPTION
## Summary

- `fz skills` の探索 root に `$HOME/.<host>/skills` (claude/codex/copilot/gemini/agents) に加えて, 現在の git リポジトリ root 直下の同名ディレクトリを追加。
- リポジトリ由来の skill は host 表示を `<repo-name>:<host>` (例: `dotfiles:claude/commit`) として `$HOME` 由来と区別。
- 補完 (`_fz_skill_names`) も同じ仕様で更新し, `_describe` が壊れないよう候補内のコロンを backslash でエスケープ。
- `_ymt_fz_skill_roots` の戻り値を改行区切り配列として読み, 空白を含むリポジトリパス (例: `~/Projects/my repo/.claude/skills`) でも skill が検出できるように修正。

## 背景

skill の管理方法が変わり, `$HOME` だけでなくリポジトリごとに `.claude/skills` 等を置くケースが出てきた。`fz skills` でそれらを家側 skill と一覧に並べて preview / 起動できるようにする。

## Commits

- `feat(zsh): fz skills が現在の git repo 直下も探索するよう拡張` — 探索 root の追加と `repo:<host>` 表記の導入
- `refactor(zsh): fz skills の repo 由来 host 表示を repo 名に変更` — 固定 prefix から `<repo-name>:<host>` に変更し複数 repo を区別可能に
- `fix(zsh): fz skills の repo-local 経路で空白パスとコロンを正しく扱う` — Codex review 指摘に対応 (whitespace path の word-splitting / `_describe` 候補のコロンエスケープ)

## Test plan

- [x] `zsh -n .zsh/functions/fz` / `zsh -n .zsh/functions/_fz` が pass する
- [x] 一時 git repo に `.claude/skills/<name>/SKILL.md` を作成して `_ymt_fz_skills_list` が repo skill を列挙することを確認
- [x] home `.agents/skills/commit` と repo `.claude/skills/commit` の名前衝突時, 表示が `agents/commit` と `<repo-name>:claude/commit` に分かれることを確認
- [x] パスに空白を含む repo (`my repo/.codex/skills/...`) でも skill が拾われることを確認
- [x] 補完候補生成のコードを inline 実行して `<repo-name>\:claude/<name>` のように `:` がエスケープされた状態で emit されることを確認
- [ ] 実環境で `source ~/.zshrc` 後 `fz skills` を引数なし起動して repo 由来 skill が一覧に出ることを目視確認
- [ ] `fz skills <TAB>` で repo:host 形式の候補が補完できることを目視確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)