### PR TITLE
fix(zsh): asdf shims を .zshenv で PATH に追加する

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -50,6 +50,7 @@ local add_path_dirs=(
   $HOME/.lmstudio/bin
   $HOME/.local/bin
   $HOME/.antigravity/antigravity/bin
+  ${ASDF_DATA_DIR:-$HOME/.asdf}/shims
 )
 # Add GOPATH/bin only if GOPATH is defined
 [[ -n "$GOPATH" && -d "$GOPATH/bin" ]] && add_path_dirs+=("$GOPATH/bin")


### PR DESCRIPTION
## Summary

asdf 管理下のコマンドを非対話シェル (Claude Code やスクリプト経由) からも解決できるように, shims のパス追加を `.zshrc` から `.zshenv` に移します。

## Key Changes

- `.zshenv` の `add_path_dirs` 配列に `${ASDF_DATA_DIR:-$HOME/.asdf}/shims` を追加
- 既存の「ディレクトリが存在する場合のみ PATH 先頭に追加」ループにそのまま乗せたため, `commands[asdf]` 判定や追加分岐は不要

## Impact

- `.zshenv` は対話／非対話を問わず読み込まれるため, `zsh -c '...'` や GUI から起動されるツールでも shims が PATH に入るようになります
- 対話シェルでは `.zshrc` の `asdf.sh` source 後に active version の `installs/<plugin>/<version>/bin` が前に積まれるため shims が PATH の最先頭にはならないことがありますが, shims が PATH に含まれていれば asdf 管理下のコマンドは解決されるため動作上の問題はありません
- `.zshenv.zwc` は既存の zcompile ロジックがタイムスタンプ比較で再生成するので追加対応不要

## Test plan

- [x] `zsh -n .zshenv` で構文チェック
- [x] `zsh -c 'echo $PATH'` (非対話) で `~/.asdf/shims` が PATH 先頭付近に含まれることを確認
- [x] `zsh -i -c 'echo $PATH'` (対話) で `~/.asdf/shims` が PATH に含まれ, asdf 管理下のコマンドが解決できることを確認
