### PR TITLE
feat(nvim): :Translate で Gemini 日本語訳を追加

### DIFF
--- a/.config/nvim/lua/config/keymaps.lua
+++ b/.config/nvim/lua/config/keymaps.lua
@@ -1,5 +1,5 @@
 -- ============================================================================
--- Keyboard Shortcuts Configuration
+-- Keyboard Shortcuts and Lightweight User Commands
 -- Migrated from .vimrc lines 207-228
 -- ============================================================================
 
@@ -44,3 +44,15 @@ vim.api.nvim_create_autocmd('FileType', {
     end, { buffer = true, noremap = true, desc = 'Paste/convert URL as Markdown link' })
   end,
 })
+
+-- ============================================================================
+-- TRANSLATE TO JAPANESE (Gemini API)
+-- ============================================================================
+
+vim.api.nvim_create_user_command('Translate', function(opts)
+  if opts.range > 0 then
+    require('utils.translate').translate(opts.line1, opts.line2)
+  else
+    require('utils.translate').translate()
+  end
+end, { range = true, desc = 'Translate buffer or range to Japanese (Gemini)' })

--- a/.config/nvim/lua/utils/translate.lua
+++ b/.config/nvim/lua/utils/translate.lua
@@ -1,0 +1,142 @@
+-- 任意のテキストを日本語に翻訳するユーティリティ。Gemini API を使用する。
+--
+-- 必要な環境変数:
+--   GEMINI_API_KEY  : Google AI Studio (https://aistudio.google.com/app/apikey) で発行する API キー
+--   GEMINI_MODEL    : 任意。デフォルトは gemini-2.5-flash
+--
+-- 公開 API:
+--   M.translate(line1, line2)  : 行範囲を翻訳。引数なしならバッファ全体
+--   M.translate_buffer()       : バッファ全体を翻訳
+--   M.translate_range(l1, l2)  : 行範囲を翻訳
+
+local M = {}
+
+local DEFAULT_MODEL = 'gemini-2.5-flash'
+
+local PROMPT = [[以下のテキストを自然な日本語に翻訳してください。
+
+制約:
+- 元のフォーマット (Markdown 構文, インデント, 改行, 箇条書き, テーブル, コードブロック等) を保持する
+- コードブロックやインラインコード内のコード本体は翻訳せず, コメントや文字列のうち訳すべき部分のみ翻訳する
+- 固有名詞, コマンド名, ライブラリ名, ファイルパス, URL, 技術用語は原文を尊重する
+- 翻訳結果のみを出力し, 前置き・後書き・コードフェンスでの全体囲みは付けない
+
+----
+]]
+
+local function get_api_key()
+  local key = vim.env.GEMINI_API_KEY
+  if not key or key == '' then
+    vim.notify('GEMINI_API_KEY is not set', vim.log.levels.ERROR)
+    return nil
+  end
+  return key
+end
+
+local function open_result_split(text, source_ft)
+  vim.cmd('vsplit')
+  vim.cmd('enew')
+  local buf = vim.api.nvim_get_current_buf()
+  vim.bo[buf].buftype = 'nofile'
+  vim.bo[buf].bufhidden = 'wipe'
+  vim.bo[buf].swapfile = false
+  if source_ft and source_ft ~= '' then
+    vim.bo[buf].filetype = source_ft
+  end
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, vim.split(text, '\n', { plain = true }))
+end
+
+local function call_gemini(text, source_ft, on_done)
+  local api_key = get_api_key()
+  if not api_key then
+    return
+  end
+
+  local model = vim.env.GEMINI_MODEL or DEFAULT_MODEL
+  local url = string.format(
+    'https://generativelanguage.googleapis.com/v1beta/models/%s:generateContent?key=%s',
+    model,
+    api_key
+  )
+
+  local body = vim.json.encode({
+    contents = {
+      { parts = { { text = PROMPT .. text } } },
+    },
+    generationConfig = {
+      temperature = 0.2,
+    },
+  })
+
+  vim.notify('Translating with ' .. model .. '...', vim.log.levels.INFO)
+
+  vim.system(
+    { 'curl', '-sS', '-X', 'POST', '-H', 'Content-Type: application/json', '--data-binary', '@-', url },
+    { stdin = body, text = true },
+    function(result)
+      vim.schedule(function()
+        if result.code ~= 0 then
+          vim.notify('curl failed (exit ' .. result.code .. '): ' .. (result.stderr or ''), vim.log.levels.ERROR)
+          return
+        end
+
+        local ok, decoded = pcall(vim.json.decode, result.stdout)
+        if not ok then
+          vim.notify('Failed to decode response: ' .. result.stdout, vim.log.levels.ERROR)
+          return
+        end
+
+        if decoded.error then
+          local msg = (decoded.error and decoded.error.message) or vim.inspect(decoded.error)
+          vim.notify('Gemini error: ' .. msg, vim.log.levels.ERROR)
+          return
+        end
+
+        local candidate = decoded.candidates and decoded.candidates[1]
+        local parts = candidate and candidate.content and candidate.content.parts or {}
+        local text_out = parts[1] and parts[1].text or ''
+
+        if text_out == '' then
+          vim.notify('Empty translation: ' .. vim.inspect(decoded), vim.log.levels.WARN)
+          return
+        end
+
+        on_done(text_out, source_ft)
+      end)
+    end
+  )
+end
+
+--- 行範囲 [line1, line2] (1-based, inclusive) を翻訳して別ウィンドウに表示する。
+---@param line1 integer
+---@param line2 integer
+function M.translate_range(line1, line2)
+  local lines = vim.api.nvim_buf_get_lines(0, line1 - 1, line2, false)
+  local text = table.concat(lines, '\n')
+  if vim.trim(text) == '' then
+    vim.notify('Selection is empty', vim.log.levels.WARN)
+    return
+  end
+  local source_ft = vim.bo.filetype
+  call_gemini(text, source_ft, open_result_split)
+end
+
+--- バッファ全体を翻訳して別ウィンドウに表示する。
+function M.translate_buffer()
+  local last = vim.api.nvim_buf_line_count(0)
+  M.translate_range(1, last)
+end
+
+--- ユーザーコマンド/キーマップから呼ぶエントリポイント。
+--- 引数が無い場合はバッファ全体を翻訳する。
+---@param line1 integer|nil
+---@param line2 integer|nil
+function M.translate(line1, line2)
+  if line1 and line2 then
+    M.translate_range(line1, line2)
+  else
+    M.translate_buffer()
+  end
+end
+
+return M


### PR DESCRIPTION
## 概要

任意のバッファや行範囲を Gemini API で日本語に翻訳する `:Translate` コマンドを Neovim に追加します。閲覧中の英語 Markdown / コードコメント / プレーンテキストを別ウィンドウで素早く読めるようにするのが目的です。

## 主な変更

- **`lua/utils/translate.lua` (新規)**
  - `vim.system` + `curl` で Gemini API (`gemini-2.5-flash`) を非同期呼び出し
  - レスポンスをパースして vsplit のスクラッチバッファに表示
  - 結果バッファは元バッファの filetype を引き継ぐ (markdown → markdown 等)
- **`lua/config/keymaps.lua`**
  - `:Translate` ユーザーコマンドを登録 (range 対応)
  - ヘッダーコメントを「Keyboard Shortcuts and Lightweight User Commands」に更新

## 使い方

| 操作 | 動作 |
|---|---|
| `:Translate` | バッファ全体を翻訳 |
| `:'<,'>Translate` | visual 選択範囲 (line-wise) を翻訳 |
| `:5,20Translate` | 指定行範囲を翻訳 |

### セットアップ

1. https://aistudio.google.com/app/apikey で API キーを発行 (クレカ不要)
2. `~/.zshrc_local` 等に以下を追加:
   ```sh
   export GEMINI_API_KEY="AIza..."
   ```
3. シェル再読み込み後 `nvim` 起動 → `:Translate`

モデルを変えたい場合は `GEMINI_MODEL` を上書き。

## 設計メモ

- DeepL API Free は 2025-2026 で「1 回限り 100 万文字 + 従量課金」モデルへ変更されたため採用見送り
- LLM (Gemini) 経由のため Markdown のコードブロック / リンク / 見出しなどの構造が崩れにくい
- 非同期実行 (`vim.system` callback) で翻訳中も nvim 操作可能
- 結果バッファは `bufhidden=wipe` のスクラッチ。`:w` で必要なら保存可

## 検証

- [x] `nvim --headless` で config の読み込みエラーなし
- [x] `:Translate` コマンドが登録されること (`vim.fn.exists` で確認)
- [x] モジュールの公開関数 (`translate`, `translate_buffer`, `translate_range`) が export されること
- [ ] 実環境での API 呼び出し動作確認 (要 GEMINI_API_KEY セットアップ)

## 参考

- [Google AI Studio - API Keys](https://aistudio.google.com/app/apikey)
- [Gemini API - Generate Content](https://ai.google.dev/api/generate-content)