### PR TITLE
fix(nvim): VimR では image.nvim を読み込まない

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -48,6 +48,10 @@ return {
   {
     '3rd/image.nvim',
     ft = 'markdown',
+    -- VimR などの GUI クライアントは Kitty graphics protocol 非対応のため除外
+    cond = function()
+      return vim.g.gui_vimr ~= 1
+    end,
     config = function()
       require('image').setup({
         backend = 'kitty',  -- Ghostty + tmux: Kitty protocol with passthrough


### PR DESCRIPTION
## Summary
- VimR で markdown を開くと image.nvim が `cannot query terminal size` を出していた
- VimR は Kitty graphics protocol 非対応の GUI クライアントのため、`g:gui_vimr` を `cond` で見て image.nvim 自体をスキップ

## Test plan
- [ ] VimR で markdown ファイルを開き、エラーが出ないことを確認
- [ ] ターミナルの nvim (Ghostty + tmux) で markdown を開き、画像レンダリングが従来通り動くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)