### PR TITLE
feat(skills): internal-skills を Makefile からインストール／更新できるようにする

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Symbolic link を通じて各種ツールやアプリケーションの設定フ
 - `make setup_develop` : 開発機向けの軽量構成を導入します。
 - `make link` / `make unlink` : `$HOME` 配下へシンボリックリンクを張る／解除します。
 - `make asdf_update` : asdf プラグインを最新化します。ランタイム更新時に再実行してください。
-- `make skills` / `make skills_update` / `make skills_link` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新します。`skills_link` は `$HOME/.claude/skills` への symlink のみ再生成します。`gh auth login` 済みであることが前提です。
+- `make skills` / `make skills_update` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新します。`gh auth login` 済みであることが前提です。
 
 ## コーディングスタイルと命名規則
 - スクリプトは `/bin/sh` シバンと `set -e` を基本とし, 四スペースインデントを推奨します。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ Symbolic link を通じて各種ツールやアプリケーションの設定フ
 - `make setup_develop` : 開発機向けの軽量構成を導入します。
 - `make link` / `make unlink` : `$HOME` 配下へシンボリックリンクを張る／解除します。
 - `make asdf_update` : asdf プラグインを最新化します。ランタイム更新時に再実行してください。
+- `make skills` / `make skills_update` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新します。`gh auth login` 済みであることが前提です。
 
 ## コーディングスタイルと命名規則
 - スクリプトは `/bin/sh` シバンと `set -e` を基本とし, 四スペースインデントを推奨します。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Symbolic link を通じて各種ツールやアプリケーションの設定フ
 - `make setup_develop` : 開発機向けの軽量構成を導入します。
 - `make link` / `make unlink` : `$HOME` 配下へシンボリックリンクを張る／解除します。
 - `make asdf_update` : asdf プラグインを最新化します。ランタイム更新時に再実行してください。
-- `make skills` / `make skills_update` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新します。`gh auth login` 済みであることが前提です。
+- `make skills` / `make skills_update` / `make skills_link` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新します。`skills_link` は `$HOME/.claude/skills` への symlink のみ再生成します。`gh auth login` 済みであることが前提です。
 
 ## コーディングスタイルと命名規則
 - スクリプトは `/bin/sh` シバンと `set -e` を基本とし, 四スペースインデントを推奨します。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@ Symbolic link を通じて各種ツールやアプリケーションの設定フ
 - `make setup_develop` : 開発機向けの軽量構成を導入します。
 - `make link` / `make unlink` : `$HOME` 配下へシンボリックリンクを張る／解除します。
 - `make asdf_update` : asdf プラグインを最新化します。ランタイム更新時に再実行してください。
-- `make skills` / `make skills_update` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新します。`gh auth login` 済みであることが前提です。
+- `make skills` / `make skills_update` / `make skills_uninstall` : 社内共通 skill (`fillin-inc/internal-skills`) をインストール／更新／アンインストールします。`gh auth login` 済みであることが前提です。
 
 ## コーディングスタイルと命名規則
 - スクリプトは `/bin/sh` シバンと `set -e` を基本とし, 四スペースインデントを推奨します。

--- a/Makefile
+++ b/Makefile
@@ -78,10 +78,6 @@ skills: ## Install internal-skills for Claude Code / Codex / Copilot / Gemini
 skills_update: ## Update internal-skills to latest versions
 	sh ./bin/install_skills.sh update
 
-.PHONY: skills_link
-skills_link: ## Create symlinks under $HOME/.claude/skills (skip if exists)
-	sh ./bin/install_skills.sh link
-
 .PHONY: asdf_nodejs
 asdf_nodejs: ## Install NodeJS
 	sh ./bin/asdf/nodejs.sh

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ skills_update: ## Update internal-skills to latest versions
 	sh ./bin/install_skills.sh update
 
 .PHONY: skills_link
-skills_link: ## Re-create symlinks under $HOME/.claude/skills
+skills_link: ## Create symlinks under $HOME/.claude/skills (skip if exists)
 	sh ./bin/install_skills.sh link
 
 .PHONY: asdf_nodejs

--- a/Makefile
+++ b/Makefile
@@ -74,6 +74,10 @@ claude_code: ## Install Claude Code CLI
 skills: ## Install internal-skills for Claude Code / Codex / Copilot / Gemini
 	sh ./bin/install_skills.sh install
 
+.PHONY: skills_uninstall
+skills_uninstall: ## Uninstall internal-skills from all agent directories
+	sh ./bin/install_skills.sh uninstall
+
 .PHONY: skills_update
 skills_update: ## Update internal-skills to latest versions
 	sh ./bin/install_skills.sh update

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,18 @@ asdf_terraform: asdf_cloud ## Install Terraform Tools
 claude_code: ## Install Claude Code CLI
 	sh ./bin/claude_code.sh
 
+.PHONY: skills
+skills: ## Install internal-skills for Claude Code / Codex / Copilot / Gemini
+	sh ./bin/install_skills.sh install
+
+.PHONY: skills_update
+skills_update: ## Update internal-skills to latest versions
+	sh ./bin/install_skills.sh update
+
+.PHONY: skills_link
+skills_link: ## Re-create symlinks under $HOME/.claude/skills
+	sh ./bin/install_skills.sh link
+
 .PHONY: asdf_nodejs
 asdf_nodejs: ## Install NodeJS
 	sh ./bin/asdf/nodejs.sh

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -2,46 +2,27 @@
 set -e
 
 REPO="fillin-inc/internal-skills"
-AGENTS_SKILLS_DIR="$HOME/.agents/skills"
-CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
 SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify task"
 
 do_install() {
-    mkdir -p "$AGENTS_SKILLS_DIR"
     for skill in $SKILLS; do
-        gh skill install "$REPO" "$skill" --dir "$AGENTS_SKILLS_DIR" --force
+        # $HOME/.agents/skills に配置 (Codex / Copilot / Gemini CLI が共用)
+        gh skill install "$REPO" "$skill" --agent codex --scope user --force
+        # $HOME/.claude/skills に配置 (Claude Code)
+        gh skill install "$REPO" "$skill" --agent claude-code --scope user --force
     done
-    do_link
 }
 
 do_update() {
     gh skill update --all
-    do_link
-}
-
-do_link() {
-    mkdir -p "$CLAUDE_SKILLS_DIR"
-    for skill in $SKILLS; do
-        dst="$CLAUDE_SKILLS_DIR/$skill"
-        src="$AGENTS_SKILLS_DIR/$skill"
-        if [ -L "$dst" ]; then
-            echo "exist: $dst"
-        elif [ -e "$dst" ]; then
-            echo "WARN: skip (real file/dir exists): $dst"
-        else
-            echo "link: $dst"
-            ln -s "$src" "$dst"
-        fi
-    done
 }
 
 CMD="${1:-install}"
 case "$CMD" in
     install) do_install ;;
     update)  do_update ;;
-    link)    do_link ;;
     *)
-        echo "Usage: install_skills.sh [install|update|link]" >&2
+        echo "Usage: install_skills.sh [install|update]" >&2
         exit 1
         ;;
 esac

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -1,0 +1,47 @@
+#!/bin/sh
+set -e
+
+REPO="fillin-inc/internal-skills"
+AGENTS_SKILLS_DIR="$HOME/.agents/skills"
+CLAUDE_SKILLS_DIR="$HOME/.claude/skills"
+SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify task"
+
+do_install() {
+    mkdir -p "$AGENTS_SKILLS_DIR"
+    for skill in $SKILLS; do
+        gh skill install "$REPO/$skill" --dir "$AGENTS_SKILLS_DIR" --force
+    done
+    do_link
+}
+
+do_update() {
+    gh skill update --all
+    do_link
+}
+
+do_link() {
+    mkdir -p "$CLAUDE_SKILLS_DIR"
+    for skill in $SKILLS; do
+        dst="$CLAUDE_SKILLS_DIR/$skill"
+        src="$AGENTS_SKILLS_DIR/$skill"
+        if [ -L "$dst" ]; then
+            echo "exist: $dst"
+        elif [ -e "$dst" ]; then
+            echo "WARN: skip (real file/dir exists): $dst"
+        else
+            echo "link: $dst"
+            ln -s "$src" "$dst"
+        fi
+    done
+}
+
+CMD="${1:-install}"
+case "$CMD" in
+    install) do_install ;;
+    update)  do_update ;;
+    link)    do_link ;;
+    *)
+        echo "Usage: install_skills.sh [install|update|link]" >&2
+        exit 1
+        ;;
+esac

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -6,7 +6,7 @@ SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify ta
 
 do_install() {
     for skill in $SKILLS; do
-        # $HOME/.agents/skills に配置 (Codex / Copilot / Gemini CLI が共用)
+        # $HOME/.codex/skills に配置 (Codex)
         gh skill install "$REPO" "$skill" --agent codex --scope user --force
         # $HOME/.claude/skills に配置 (Claude Code)
         gh skill install "$REPO" "$skill" --agent claude-code --scope user --force

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -6,10 +6,26 @@ SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify ta
 
 do_install() {
     for skill in $SKILLS; do
+        # $HOME/.agents/skills に配置 (Copilot / Gemini CLI 等が共用)
+        gh skill install "$REPO" "$skill" --dir "$HOME/.agents/skills" --force
         # $HOME/.codex/skills に配置 (Codex)
         gh skill install "$REPO" "$skill" --agent codex --scope user --force
         # $HOME/.claude/skills に配置 (Claude Code)
         gh skill install "$REPO" "$skill" --agent claude-code --scope user --force
+    done
+}
+
+do_uninstall() {
+    for skill in $SKILLS; do
+        for dir in "$HOME/.agents/skills" "$HOME/.codex/skills" "$HOME/.claude/skills"; do
+            target="$dir/$skill"
+            if [ -e "$target" ] || [ -L "$target" ]; then
+                echo "remove: $target"
+                rm -rf "$target"
+            else
+                echo "not-exist: $target"
+            fi
+        done
     done
 }
 
@@ -19,10 +35,11 @@ do_update() {
 
 CMD="${1:-install}"
 case "$CMD" in
-    install) do_install ;;
-    update)  do_update ;;
+    install)   do_install ;;
+    uninstall) do_uninstall ;;
+    update)    do_update ;;
     *)
-        echo "Usage: install_skills.sh [install|update]" >&2
+        echo "Usage: install_skills.sh [install|uninstall|update]" >&2
         exit 1
         ;;
 esac

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -6,10 +6,8 @@ SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify ta
 
 do_install() {
     for skill in $SKILLS; do
-        # $HOME/.agents/skills に配置 (Copilot / Gemini CLI 等が共用)
+        # $HOME/.agents/skills に配置 (Codex / Copilot / Gemini CLI 等が共用)
         gh skill install "$REPO" "$skill" --dir "$HOME/.agents/skills" --force
-        # $HOME/.codex/skills に配置 (Codex)
-        gh skill install "$REPO" "$skill" --agent codex --scope user --force
         # $HOME/.claude/skills に配置 (Claude Code)
         gh skill install "$REPO" "$skill" --agent claude-code --scope user --force
     done
@@ -17,7 +15,7 @@ do_install() {
 
 do_uninstall() {
     for skill in $SKILLS; do
-        for dir in "$HOME/.agents/skills" "$HOME/.codex/skills" "$HOME/.claude/skills"; do
+        for dir in "$HOME/.agents/skills" "$HOME/.claude/skills"; do
             target="$dir/$skill"
             if [ -e "$target" ] || [ -L "$target" ]; then
                 echo "remove: $target"

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -9,7 +9,7 @@ SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify ta
 do_install() {
     mkdir -p "$AGENTS_SKILLS_DIR"
     for skill in $SKILLS; do
-        gh skill install "$REPO/$skill" --dir "$AGENTS_SKILLS_DIR" --force
+        gh skill install "$REPO" "$skill" --dir "$AGENTS_SKILLS_DIR" --force
     done
     do_link
 }

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -7,7 +7,7 @@ SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify ta
 do_install() {
     for skill in $SKILLS; do
         # $HOME/.agents/skills に配置 (Codex / Copilot / Gemini CLI 等が共用)
-        gh skill install "$REPO" "$skill" --dir "$HOME/.agents/skills" --force
+        gh skill install "$REPO" "$skill" --dir "$HOME/.agents/skills" --agent github-copilot --force
         # $HOME/.claude/skills に配置 (Claude Code)
         gh skill install "$REPO" "$skill" --agent claude-code --scope user --force
     done


### PR DESCRIPTION
## Summary

`fillin-inc/internal-skills` の 9 つの共通 skill を Claude Code / Codex / Copilot / Gemini CLI から利用できるよう、Makefile からインストール・更新できる仕組みを追加します。

## Key Changes

- `bin/install_skills.sh` を新規作成
  - `install`: `gh skill install` で 9 skill を `$HOME/.agents/skills/` に実体インストールし、`$HOME/.claude/skills/` に symlink を作成
  - `update`: `gh skill update --all` で全 skill を更新後、symlink を再リンク
  - `link`: symlink のみ再生成（実体に衝突があれば WARN でスキップ）
- `Makefile` に `skills` / `skills_update` / `skills_link` の 3 ターゲットを追加（`claude_code` ターゲット近傍）
- `AGENTS.md` のビルドコマンド一覧に `make skills` / `make skills_update` を追記

## Impact

- `setup` / `setup_develop` には組み込まない（`gh auth login` 前提のため手動実行）
- 既存の `$HOME/.claude/skills/<name>` に実体ファイルがある場合は WARN でスキップし破壊しない

Closes #138
