### PR TITLE
feat(skills): install_skills の対象 skill を最新化

### DIFF
--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -2,7 +2,7 @@
 set -e
 
 REPO="fillin-inc/internal-skills"
-SKILLS="code-review commit implement issue pr spec-issue spec-to-plan specify task"
+SKILLS="code-review commit implement issue pr spec-issue spec-to-plan spec task"
 
 do_install() {
     for skill in $SKILLS; do

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -2,7 +2,7 @@
 set -e
 
 REPO="fillin-inc/internal-skills"
-SKILLS="code-review commit implement issue pr spec-issue spec-to-plan spec task"
+SKILLS="agents-init code-review commit implement issue pr spec-issue spec-to-plan spec task"
 
 do_install() {
     for skill in $SKILLS; do


### PR DESCRIPTION
## Summary
`bin/install_skills.sh` の `SKILLS` リストを internal-skills の最新ラインナップに追従する。

## Key Changes
- `specify` skill を `spec` にリネーム
- `agents-init` skill を新規にインストール対象へ追加

## Impact
- `make skills` / `make skills_update` 実行時のインストール／更新対象が変わる
- 旧 `specify` skill をインストール済みの環境では `make skills_uninstall` 後に再インストールするのが望ましい
