### PR TITLE
feat(hammerspoon): Ctrl+J 改行ショートカットの対象アプリを追加・整列

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -103,11 +103,15 @@ toggleIMESwitcher:start()
 
 -- Ctrl+J で改行を挿入 (特定アプリ限定)
 local ctrlJTargetApps = {
-  ["Slack"] = true,
-  ["Obsidian"] = true,
-  ["Google Chrome"] = true,
-  ["Claude"] = true,
+  ["Brave"] = true,
   ["ChatGPT"] = true,
+  ["Claude"] = true,
+  ["Firefox"] = true,
+  ["Gemini"] = true,
+  ["Google Chrome"] = true,
+  ["Obsidian"] = true,
+  ["Safari"] = true,
+  ["Slack"] = true,
 }
 
 local ctrlJHotkey = hs.hotkey.new({ "ctrl" }, "j", function()


### PR DESCRIPTION
## Summary

Hammerspoon の Ctrl+J 改行ショートカット対象アプリに Brave, Firefox, Gemini, Safari を追加し, リストをアルファベット順に整列した。

## Key Changes

- `ctrlJTargetApps` に以下のアプリを追加:
  - Brave Browser
  - Firefox
  - Gemini
  - Safari
- 既存エントリ (ChatGPT, Claude, Google Chrome, Obsidian, Slack) はそのまま維持
- アルファベット順に並び替えて可読性を向上

## Impact

- 追加したブラウザ・AI アプリで Ctrl+J が改行として機能するようになる
- 既存の動作に影響はない
