### PR TITLE
feat(ghostty): Cmd+Q による誤終了を防ぐため super+q を無効化

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -45,6 +45,7 @@ window-new-tab-position = end
 
 # Keybindings
 keybind = super+n=new_tab
+keybind = super+q=ignore
 
 # Others
 mouse-hide-while-typing = true


### PR DESCRIPTION
## 概要

Ghostty で `Cmd+Q` を押し間違えてアプリが終了してしまう問題を防ぐため、`super+q=ignore` を設定に追加しました。

## 変更内容

- `.config/ghostty/config` に `keybind = super+q=ignore` を追加

## 検証手順

1. `make link` で設定をリンク
2. Ghostty を再起動
3. `Cmd+Q` を押してもアプリが終了しないことを確認
4. アプリ終了はメニューバーの `Ghostty > Quit` から行う

🤖 Generated with [Claude Code](https://claude.com/claude-code)