### PR TITLE
feat(fz): サブコマンド単位の --help を追加 + aws-sso help に profile 追加手順

### DIFF
--- a/.zsh/functions/aws-sso
+++ b/.zsh/functions/aws-sso
@@ -15,6 +15,26 @@ aws-sso は IAM Identity Center (SSO) 経由の AWS ログインと AWS_PROFILE 
     成功した場合のみ AWS_PROFILE=<profile> を export します.
     <profile> は ~/.aws/config の SSO profile のみ指定可能です.
 
+profile の追加方法:
+    list / login が拾うのは ~/.aws/config に書かれた SSO profile だけです.
+    AWS access portal でロールが増えても自動反映されないため,
+    新しい account / role を使うには以下のいずれかで profile を追記します.
+
+    1) 手動で ~/.aws/config に追記する (既存 sso_session を再利用)
+
+        [profile <profile-name>]
+        sso_session = <session-name>
+        sso_account_id = <account-id>
+        sso_role_name = <role-name>      # 例: Developer / ReadOnlyAccess
+        region = ap-northeast-1
+        output = json
+
+    2) aws CLI に対話で追加させる
+
+        aws configure sso --sso-session <session-name>
+
+    追記後に aws-sso list / fz aws-sso に出てくるようになります.
+
 依存関係:
     aws CLI
 EOF

--- a/.zsh/functions/fz
+++ b/.zsh/functions/fz
@@ -246,6 +246,30 @@ _ymt_fz_log() {
 
 # プロセスkill
 _ymt_fz_kill() {
+  case "${1:-}" in
+    -h|--help)
+      cat <<'EOF'
+fz kill - プロセスを検索して kill する
+
+Usage: fz kill [signal]
+
+Arguments:
+  signal    送信するシグナル番号または名前 (デフォルト: 9 = SIGKILL)
+            例: TERM, HUP, INT, 9, 15
+
+Behavior:
+  ps -eo の一覧から fzf で選択. TAB で複数選択可.
+  プレビューに対象プロセス + 子プロセス一覧を表示.
+
+Examples:
+  fz kill        # SIGKILL (-9) で kill
+  fz kill 15     # SIGTERM (-15) で kill
+  fz kill TERM   # 同上 (名前指定)
+EOF
+      return 0
+      ;;
+  esac
+
   local pid
   local list
   list=$(LC_ALL=C ps -eo pid,user,pcpu,pmem,etime,args \
@@ -320,6 +344,31 @@ _ymt_fz_collect_descendants() {
 
 # dev サーバ kill
 _ymt_fz_devkill() {
+  case "${1:-}" in
+    -h|--help)
+      cat <<'EOF'
+fz devkill - 開発サーバプロセスを検索して子孫プロセスごと kill
+
+Usage: fz devkill
+
+Behavior:
+  正規表現でマッチしたプロセスのみ候補に出し, 選択した root から
+  子孫 PID を BFS で収集して SIGTERM → 0.5s 後に残っていれば SIGKILL.
+
+Detected patterns:
+  pnpm dev / pnpm run dev / npm run dev / yarn dev / bun dev
+  vite / webpack-dev-server / next-server / next dev / nuxt dev
+  astro dev / remix dev / turbo run dev / svelte-kit dev
+
+  対象外: 上記以外 (独自スクリプトなどは検出されません)
+
+Examples:
+  fz devkill
+EOF
+      return 0
+      ;;
+  esac
+
   local self_pid=$$
   local list
   list=$(LC_ALL=C ps -eo pid,ppid,user,etime,pcpu,pmem,command \
@@ -634,6 +683,25 @@ _ymt_fz_lazygit() {
 
 # ファイル検索
 _ymt_fz_find() {
+  case "${1:-}" in
+    -h|--help)
+      cat <<'EOF'
+fz find - ファイル検索 (fd を使用)
+
+Usage: fz find
+
+Behavior:
+  fd -t f でファイル一覧を取得し fzf で選択.
+  選択したパスを stdout に出力 + pbcopy が存在すればクリップボードにコピー.
+  .gitignore は尊重される.
+
+Examples:
+  fz find
+EOF
+      return 0
+      ;;
+  esac
+
   # fdコマンドの存在チェック
   if ! (( $+commands[fd] )); then
     echo "Error: fd command is required for find subcommand" >&2
@@ -815,6 +883,36 @@ _ymt_fz_skills_pick() {
 }
 
 _ymt_fz_skills() {
+  case "${1:-}" in
+    -h|--help)
+      cat <<'EOF'
+fz skills - skill (SKILL.md + 関連ファイル) を mo でブラウザ表示
+
+Usage: fz skills [<name>]
+
+Arguments:
+  <name>    skill 名 (省略時は fzf で選択)
+            "<host>/<name>" 形式で host を限定指定可
+            host: claude / codex / copilot / gemini / agents
+                  または "<repo>:<host>" ($HOME 直下以外の root)
+
+Resolution:
+  1) display 名 ("<host>/<name>" 含む) と完全一致するもの
+  2) basename 一致. 複数 host にまたがる場合は fzf で再選択
+
+Roots:
+  $HOME/.{claude,codex,copilot,gemini,agents}/skills
+  <repo-root>/.{claude,codex,copilot,gemini,agents}/skills
+
+Examples:
+  fz skills              # 一覧から選択
+  fz skills commit       # commit skill を直接開く
+  fz skills claude/foo   # claude host の foo を直接指定
+EOF
+      return 0
+      ;;
+  esac
+
   local name target
 
   if [[ $# -gt 1 ]]; then
@@ -895,6 +993,13 @@ _ymt_fz_skills() {
 
 # AWS SSO profile 選択ログイン
 _ymt_fz_aws_sso() {
+  case "${1:-}" in
+    -h|--help)
+      aws-sso --help
+      return $?
+      ;;
+  esac
+
   local profiles
   profiles=$(aws-sso list) || return 1
 


### PR DESCRIPTION
## Summary
- `.zsh/functions/aws-sso` の usage に「profile の追加方法」セクションを追記
- `.zsh/functions/fz` の以下サブコマンドに `-h` / `--help` を追加し, トップレベル `fz --help` だけでは見えない仕様を surface
  - `aws-sso` … 自作 wrapper `aws-sso --help` に透過
  - `kill` … signal を `$1` で渡せる仕様 (`fz kill 15` 等)
  - `devkill` … 検出対象の dev サーバ正規表現一覧
  - `find` … 選択結果が `pbcopy` にコピーされる副作用
  - `skills` … 引数 1 つ受付 + host/basename 解決ルール + 探索 root

## Why
- 「`fz aws-sso` のリストが更新されない」問い合わせを起点に, `~/.aws/config` の SSO profile 登録手順がリポジトリ内のどこにも documentation されていないことが判明
- 同じく `fz <sub>` の隠れ仕様 (signal 引数 / 検出パターン / pbcopy 副作用 / skills 解決ルール) もコードを読まないと気付けず, 次回の同種問い合わせを抑える目的で `--help` を整備

## Test plan
- [x] `zsh -n .zsh/functions/{fz,aws-sso}` で構文チェック
- [x] `fz {aws-sso,kill,devkill,find,skills} --help` の出力を目視確認
- [ ] (任意) 実環境で `~/.aws/config` に新 profile を追記 → `fz aws-sso` のリストに出ることを確認