### PR TITLE
feat(zsh): tee + pbcopy を行う teecopy 関数を追加

### DIFF
--- a/.zsh/functions/teecopy
+++ b/.zsh/functions/teecopy
@@ -1,0 +1,20 @@
+#!/bin/zsh
+#
+# teecopy: stdin をターミナルに表示しつつ, ANSI escape を除去してクリップボードへコピーする。
+#
+# Usage:
+#     terraform plan | teecopy
+#     kubectl describe pod foo | teecopy
+#
+# Dependencies:
+#     pbcopy (macOS)
+
+teecopy() {
+  if ! command -v pbcopy >/dev/null 2>&1; then
+    echo "Error: pbcopy is not available (macOS required)" >&2
+    return 1
+  fi
+  tee >(sed $'s/\x1b\\[[0-9;]*m//g' | pbcopy)
+}
+
+teecopy "$@"

--- a/.zsh/functions/teecopy
+++ b/.zsh/functions/teecopy
@@ -1,15 +1,25 @@
 #!/bin/zsh
-#
-# teecopy: stdin をターミナルに表示しつつ, ANSI escape を除去してクリップボードへコピーする。
-#
-# Usage:
-#     terraform plan | teecopy
-#     kubectl describe pod foo | teecopy
-#
-# Dependencies:
-#     pbcopy (macOS)
 
-teecopy() {
+_ymt_teecopy_usage() {
+  cat <<EOF
+teecopy reads stdin, prints it to the terminal, and copies the output to the clipboard with ANSI escape sequences stripped.
+
+Usage:
+    <command> | teecopy
+
+Examples:
+    terraform plan | teecopy
+    kubectl describe pod foo | teecopy
+
+Options:
+    --help, -h         print help
+
+Dependencies:
+    pbcopy (macOS)
+EOF
+}
+
+_ymt_teecopy() {
   if ! command -v pbcopy >/dev/null 2>&1; then
     echo "Error: pbcopy is not available (macOS required)" >&2
     return 1
@@ -17,4 +27,17 @@ teecopy() {
   tee >(sed $'s/\x1b\\[[0-9;]*m//g' | pbcopy)
 }
 
-teecopy "$@"
+case ${1} in
+  -h|--help)
+    _ymt_teecopy_usage
+  ;;
+
+  '')
+    _ymt_teecopy
+  ;;
+
+  *)
+    _ymt_teecopy_usage >&2
+    return 1
+  ;;
+esac


### PR DESCRIPTION
## Summary
- `terraform plan | teecopy` のように stdin を端末に表示しつつ, ANSI escape を除去した内容を `pbcopy` に流す汎用パイプ関数を追加
- 既存の `.zsh/functions/` autoload パターンに従って配置 (completion 不要のため `_teecopy` は作らない)
- macOS 専用 (`pbcopy` 依存) — 未存在時は早期 return

## Test plan
- [x] `printf "\033[31mhello\033[0m world\n" | teecopy` で stdout に色付き表示 + `pbpaste` でプレーンテキストが取れることを確認
- [ ] 新しい zsh セッションで `terraform plan | teecopy` を実行し挙動確認
- [ ] `kubectl describe pod ...` など他コマンドでも問題ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)