### PR TITLE
feat(domain-checker): AAAA レコード対応と Shodan InternetDB 連携を追加する

### DIFF
--- a/.zsh/functions/_domain-checker
+++ b/.zsh/functions/_domain-checker
@@ -13,6 +13,8 @@ _domain-checker() {
     command)
       subcmds=(
         'a:show A records for a domain'
+        'aaaa:show AAAA records for a domain'
+        'shodan:show Shodan InternetDB info for all A/AAAA IPs'
         'mx:show MX records for a domain'
         'spf:show SPF record for a domain'
         'dkim:show DKIM record for a domain'

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -75,7 +75,8 @@ _ymt_dc_a() {
   else
     echo "$A_RECORDS" | while IFS= read -r line; do
       [[ -n "$line" ]] && echo "* $line"
-      [[ -n "$line" ]] && _ymt_dc_shodan_lookup "$line"
+      # CNAME 行は末尾が "." になるため除外し、IP のみ Shodan に投げる
+      [[ -n "$line" && "$line" != *. ]] && _ymt_dc_shodan_lookup "$line"
     done
   fi
 }
@@ -128,7 +129,7 @@ _ymt_dc_aaaa() {
   else
     echo "$AAAA_RECORDS" | while IFS= read -r line; do
       [[ -n "$line" ]] && echo "* $line"
-      [[ -n "$line" ]] && _ymt_dc_shodan_lookup "$line"
+      [[ -n "$line" && "$line" != *. ]] && _ymt_dc_shodan_lookup "$line"
     done
   fi
 }
@@ -209,7 +210,7 @@ _ymt_dc_shodan() {
     return
   fi
   echo "$ALL_IPS" | while IFS= read -r line; do
-    if [[ -n "$line" ]]; then
+    if [[ -n "$line" && "$line" != *. ]]; then
       echo "* $line"
       _ymt_dc_shodan_lookup "$line"
     fi

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -127,7 +127,6 @@ _ymt_dc_aaaa() {
   else
     echo "$AAAA_RECORDS" | while IFS= read -r line; do
       [[ -n "$line" ]] && echo "* $line"
-      [[ -n "$line" && "$line" != *. ]] && _ymt_dc_shodan_lookup "$line"
     done
   fi
 }

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -87,14 +87,14 @@ _ymt_dc_shodan_lookup() {
     echo "  (Shodan InternetDB does not support IPv6)"
     return
   fi
-  local response status body
+  local response http_status body
   if ! response=$(curl -sS -m 5 -w '\n%{http_code}' "https://internetdb.shodan.io/$ip" 2>/dev/null); then
     echo "  (Shodan API error: curl failed)"
     return
   fi
-  status="${response##*$'\n'}"
+  http_status="${response##*$'\n'}"
   body="${response%$'\n'*}"
-  case "$status" in
+  case "$http_status" in
     200)
       local ports hostnames vulns cpes tags
       ports=$(printf '%s' "$body" | jq -r 'if (.ports // []) | length > 0 then "  - ports: " + (.ports | map(tostring) | join(", ")) else "" end')
@@ -110,7 +110,7 @@ _ymt_dc_shodan_lookup() {
       echo "  (no Shodan data)"
       ;;
     *)
-      echo "  (Shodan API error: $status)"
+      echo "  (Shodan API error: $http_status)"
       ;;
   esac
 }

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -101,7 +101,7 @@ _ymt_dc_shodan_lookup() {
         (if (.hostnames // []) | length > 0 then "  - hostnames: " + (.hostnames | join(", ")) else "" end),
         (if (.vulns // []) | length > 0 then "  - vulns: " + (.vulns | join(", ")) else "" end),
         (if (.cpes // []) | length > 0 then "  - cpes: " + (.cpes | join(", ")) else "" end),
-        (if (.tags // []) | length > 0 then "  - tags: " + (.tags | join(", ")) else "" end)
+        (if (.tags // []) | length > 0 then "  - tags:\n" + (.tags | map("    - " + .) | join("\n")) else "" end)
       ' | grep -v '^$'
       ;;
     404)

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -97,10 +97,10 @@ _ymt_dc_shodan_lookup() {
   case "$http_status" in
     200)
       printf '%s' "$body" | jq -r '
-        (if (.ports // []) | length > 0 then "  - ports: " + (.ports | map(tostring) | join(", ")) else "" end),
-        (if (.hostnames // []) | length > 0 then "  - hostnames: " + (.hostnames | join(", ")) else "" end),
-        (if (.vulns // []) | length > 0 then "  - vulns: " + (.vulns | join(", ")) else "" end),
-        (if (.cpes // []) | length > 0 then "  - cpes: " + (.cpes | join(", ")) else "" end),
+        (if (.ports // []) | length > 0 then "  - ports:\n" + (.ports | map("    - " + tostring) | join("\n")) else "" end),
+        (if (.hostnames // []) | length > 0 then "  - hostnames:\n" + (.hostnames | map("    - " + .) | join("\n")) else "" end),
+        (if (.vulns // []) | length > 0 then "  - vulns:\n" + (.vulns | map("    - " + .) | join("\n")) else "" end),
+        (if (.cpes // []) | length > 0 then "  - cpes:\n" + (.cpes | map("    - " + .) | join("\n")) else "" end),
         (if (.tags // []) | length > 0 then "  - tags:\n" + (.tags | map("    - " + .) | join("\n")) else "" end)
       ' | grep -v '^$'
       ;;

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -88,7 +88,7 @@ _ymt_dc_shodan_lookup() {
     return
   fi
   local response http_status body
-  if ! response=$(curl -sS -m 5 -w '\n%{http_code}' "https://internetdb.shodan.io/$ip" 2>/dev/null); then
+  if ! response=$(curl -s -m 5 -w '\n%{http_code}' "https://internetdb.shodan.io/$ip"); then
     echo "  (Shodan API error: curl failed)"
     return
   fi
@@ -96,15 +96,13 @@ _ymt_dc_shodan_lookup() {
   body="${response%$'\n'*}"
   case "$http_status" in
     200)
-      local ports hostnames vulns cpes tags
-      ports=$(printf '%s' "$body" | jq -r 'if (.ports // []) | length > 0 then "  - ports: " + (.ports | map(tostring) | join(", ")) else "" end')
-      hostnames=$(printf '%s' "$body" | jq -r 'if (.hostnames // []) | length > 0 then "  - hostnames: " + (.hostnames | join(", ")) else "" end')
-      vulns=$(printf '%s' "$body" | jq -r 'if (.vulns // []) | length > 0 then "  - vulns: " + (.vulns | join(", ")) else "" end')
-      cpes=$(printf '%s' "$body" | jq -r 'if (.cpes // []) | length > 0 then "  - cpes: " + (.cpes | join(", ")) else "" end')
-      tags=$(printf '%s' "$body" | jq -r 'if (.tags // []) | length > 0 then "  - tags: " + (.tags | join(", ")) else "" end')
-      for _line in "$ports" "$hostnames" "$vulns" "$cpes" "$tags"; do
-        [[ -n "$_line" ]] && echo "$_line"
-      done
+      printf '%s' "$body" | jq -r '
+        (if (.ports // []) | length > 0 then "  - ports: " + (.ports | map(tostring) | join(", ")) else "" end),
+        (if (.hostnames // []) | length > 0 then "  - hostnames: " + (.hostnames | join(", ")) else "" end),
+        (if (.vulns // []) | length > 0 then "  - vulns: " + (.vulns | join(", ")) else "" end),
+        (if (.cpes // []) | length > 0 then "  - cpes: " + (.cpes | join(", ")) else "" end),
+        (if (.tags // []) | length > 0 then "  - tags: " + (.tags | join(", ")) else "" end)
+      ' | grep -v '^$'
       ;;
     404)
       echo "  (no Shodan data)"
@@ -210,10 +208,10 @@ _ymt_dc_shodan() {
     return
   fi
   echo "$ALL_IPS" | while IFS= read -r line; do
-    if [[ -n "$line" && "$line" != *. ]]; then
-      echo "* $line"
-      _ymt_dc_shodan_lookup "$line"
-    fi
+    [[ -z "$line" ]] && continue
+    echo "* $line"
+    # CNAME 行 (末尾 ".") は表示のみ。IP 行のみ Shodan に投げる
+    [[ "$line" != *. ]] && _ymt_dc_shodan_lookup "$line"
   done
 }
 

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -73,9 +73,62 @@ _ymt_dc_a() {
   if [[ -z "$A_RECORDS" ]]; then
     echo "* No A records found."
   else
-    # A_RECORDS を改行で分割し表示（whoisは重いので略）
     echo "$A_RECORDS" | while IFS= read -r line; do
       [[ -n "$line" ]] && echo "* $line"
+      [[ -n "$line" ]] && _ymt_dc_shodan_lookup "$line"
+    done
+  fi
+}
+
+_ymt_dc_shodan_lookup() {
+  local ip="$1"
+  if [[ "$ip" == *":"* ]]; then
+    echo "  (Shodan InternetDB does not support IPv6)"
+    return
+  fi
+  local response status body
+  if ! response=$(curl -sS -m 5 -w '\n%{http_code}' "https://internetdb.shodan.io/$ip" 2>/dev/null); then
+    echo "  (Shodan API error: curl failed)"
+    return
+  fi
+  status="${response##*$'\n'}"
+  body="${response%$'\n'*}"
+  case "$status" in
+    200)
+      local ports hostnames vulns cpes tags
+      ports=$(printf '%s' "$body" | jq -r 'if (.ports // []) | length > 0 then "  - ports: " + (.ports | map(tostring) | join(", ")) else "" end')
+      hostnames=$(printf '%s' "$body" | jq -r 'if (.hostnames // []) | length > 0 then "  - hostnames: " + (.hostnames | join(", ")) else "" end')
+      vulns=$(printf '%s' "$body" | jq -r 'if (.vulns // []) | length > 0 then "  - vulns: " + (.vulns | join(", ")) else "" end')
+      cpes=$(printf '%s' "$body" | jq -r 'if (.cpes // []) | length > 0 then "  - cpes: " + (.cpes | join(", ")) else "" end')
+      tags=$(printf '%s' "$body" | jq -r 'if (.tags // []) | length > 0 then "  - tags: " + (.tags | join(", ")) else "" end')
+      for _line in "$ports" "$hostnames" "$vulns" "$cpes" "$tags"; do
+        [[ -n "$_line" ]] && echo "$_line"
+      done
+      ;;
+    404)
+      echo "  (no Shodan data)"
+      ;;
+    *)
+      echo "  (Shodan API error: $status)"
+      ;;
+  esac
+}
+
+_ymt_dc_aaaa() {
+  local DOMAIN="$1"
+  local AAAA_RECORDS
+  if ! AAAA_RECORDS=$(dig aaaa +short "$DOMAIN" 2>/dev/null); then
+    echo "Error: Failed to query AAAA records for $DOMAIN" >&2
+    return 1
+  fi
+
+  echo "## AAAA records for $DOMAIN:\n"
+  if [[ -z "$AAAA_RECORDS" ]]; then
+    echo "* No AAAA records found."
+  else
+    echo "$AAAA_RECORDS" | while IFS= read -r line; do
+      [[ -n "$line" ]] && echo "* $line"
+      [[ -n "$line" ]] && _ymt_dc_shodan_lookup "$line"
     done
   fi
 }
@@ -146,9 +199,28 @@ _ymt_dc_dmarc() {
   fi
 }
 
+_ymt_dc_shodan() {
+  local DOMAIN="$1"
+  echo "## Shodan InternetDB for $DOMAIN:\n"
+  local ALL_IPS
+  ALL_IPS=$(dig a +short "$DOMAIN" 2>/dev/null; dig aaaa +short "$DOMAIN" 2>/dev/null)
+  if [[ -z "$ALL_IPS" ]]; then
+    echo "* No A/AAAA records found."
+    return
+  fi
+  echo "$ALL_IPS" | while IFS= read -r line; do
+    if [[ -n "$line" ]]; then
+      echo "* $line"
+      _ymt_dc_shodan_lookup "$line"
+    fi
+  done
+}
+
 _ymt_dc_all() {
   local DOMAIN="$1"
   _ymt_dc_a "$DOMAIN"
+  echo ""
+  _ymt_dc_aaaa "$DOMAIN"
   echo ""
   _ymt_dc_mx "$DOMAIN"
   echo ""
@@ -164,7 +236,7 @@ case $1 in
     _ymt_dc_usage
   ;;
 
-  a|mx|spf|dkim|dmarc)
+  a|aaaa|mx|spf|dkim|dmarc|shodan)
     local _SUBCMD="$1"
     if [[ -z "$2" ]]; then
       echo "Error: Please specify a domain" >&2
@@ -178,11 +250,13 @@ case $1 in
       return 1
     fi
     case $_SUBCMD in
-      a)     _ymt_dc_a     "$_DOMAIN" ;;
-      mx)    _ymt_dc_mx    "$_DOMAIN" ;;
-      spf)   _ymt_dc_spf   "$_DOMAIN" ;;
-      dkim)  _ymt_dc_dkim  "$_DOMAIN" ;;
-      dmarc) _ymt_dc_dmarc "$_DOMAIN" ;;
+      a)      _ymt_dc_a      "$_DOMAIN" ;;
+      aaaa)   _ymt_dc_aaaa   "$_DOMAIN" ;;
+      mx)     _ymt_dc_mx     "$_DOMAIN" ;;
+      spf)    _ymt_dc_spf    "$_DOMAIN" ;;
+      dkim)   _ymt_dc_dkim   "$_DOMAIN" ;;
+      dmarc)  _ymt_dc_dmarc  "$_DOMAIN" ;;
+      shodan) _ymt_dc_shodan "$_DOMAIN" ;;
     esac
   ;;
 

--- a/.zsh/functions/domain-checker
+++ b/.zsh/functions/domain-checker
@@ -1,15 +1,13 @@
 #!/bin/zsh
 
 # Check dependencies
-if ! command -v dig >/dev/null 2>&1; then
-  echo "Error: dig command not found. Please install bind-tools or dnsutils." >&2
-  return 1
-fi
-
-if ! command -v whois >/dev/null 2>&1; then
-  echo "Error: whois command not found. Please install whois." >&2
-  return 1
-fi
+for _ymt_dc_cmd in dig whois curl jq; do
+  if ! command -v "$_ymt_dc_cmd" >/dev/null 2>&1; then
+    echo "Error: $_ymt_dc_cmd command not found. Please install $_ymt_dc_cmd." >&2
+    return 1
+  fi
+done
+unset _ymt_dc_cmd
 
 # URL や path/query 付き文字列からホスト部分のみを抽出する
 # 例:
@@ -44,6 +42,8 @@ domain-checker is a simple tool to check DNS records for a domain.
 Usage:
   domain-checker <domain>          show all DNS records for a domain
   domain-checker a <domain>        show A records for a domain
+  domain-checker aaaa <domain>     show AAAA records for a domain
+  domain-checker shodan <domain>   show Shodan InternetDB info for all A/AAAA IPs
   domain-checker mx <domain>       show MX records for a domain
   domain-checker spf <domain>      show SPF record for a domain
   domain-checker dkim <domain>     show DKIM record for a domain
@@ -54,7 +54,9 @@ Options:
 
 Dependencies:
   awk
+  curl
   dig
+  jq
   whois
 EOF
 }


### PR DESCRIPTION
## Summary

`domain-checker` に AAAA レコード調査と Shodan InternetDB 連携を追加する。DNS の IPv6 対応と「IP で稼働しているサービス情報」を 1 コマンドで把握できるようにする。

## Key Changes

- **dependency チェック拡張**: 個別 `command -v` を for ループに統合し `curl` / `jq` を依存に追加
- **`_ymt_dc_aaaa`**: `dig aaaa +short` で IPv6 アドレスを取得する関数を追加、各 IP に Shodan サマリを inline 表示
- **`_ymt_dc_shodan_lookup`**: IP 1 件を InternetDB API (`https://internetdb.shodan.io/<ip>`) に投げ、ports / hostnames / vulns / cpes / tags を表示する内部ヘルパー
  - 404 → `(no Shodan data)`, IPv6 → `(Shodan InternetDB does not support IPv6)`, curl 失敗 → エラーメッセージ表示で処理継続
  - CNAME 行 (末尾 `.`) をフィルタして IP のみ Shodan に投げる
- **`_ymt_dc_shodan`**: A/AAAA 全 IP をまとめて Shodan 照会するサブコマンド関数
- **`_ymt_dc_a` / `_ymt_dc_all` 更新**: `a` に Shodan inline 表示を統合、`all` に AAAA を A の直後に挿入
- **dispatch 拡張**: case 文を `a|aaaa|mx|spf|dkim|dmarc|shodan` に拡張
- **`_domain-checker` 補完**: `aaaa` / `shodan` を候補に追加

## Impact

- `curl` / `jq` が新規依存になるため、未インストール環境では起動時エラーが出る（usage に Dependencies を記載済み）
- Shodan API は外部ネットワークアクセスを伴うため、`a` / `aaaa` / `all` コマンドの実行時間が各 IP × 最大 5 秒増加する可能性がある
- `_ymt_dc_shodan_lookup` の `status` 変数を zsh 予約変数との衝突を避けて `http_status` にリネーム済み

Closes #148
