### PR TITLE
feat(zsh): LM Studio / Antigravity CLI の PATH を追記

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -266,4 +266,11 @@ if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]]; then
   fi
 fi
 
+# Added by LM Studio CLI (lms)
+export PATH="$PATH:$HOME/.lmstudio/bin"
+# End of LM Studio CLI section
+
+# Added by Antigravity CLI installer
+export PATH="$HOME/.local/bin:$PATH"
+
 [ -n "$ZSH_PROFILE" ] && zprof | less

--- a/.zshrc
+++ b/.zshrc
@@ -267,10 +267,10 @@ if command -v tmx >/dev/null 2>&1 && [[ -z "$TMUX" ]]; then
 fi
 
 # Added by LM Studio CLI (lms)
-export PATH="$PATH:$HOME/.lmstudio/bin"
+[ -x "$HOME/.lmstudio/bin/lms" ] && export PATH="$PATH:$HOME/.lmstudio/bin"
 # End of LM Studio CLI section
 
 # Added by Antigravity CLI installer
-export PATH="$HOME/.local/bin:$PATH"
+[ -x "$HOME/.local/bin/agy" ] && export PATH="$HOME/.local/bin:$PATH"
 
 [ -n "$ZSH_PROFILE" ] && zprof | less


### PR DESCRIPTION
## Summary
- LM Studio CLI (`lms`) / Antigravity CLI installer が自動追記した PATH 設定を `.zshrc` に取り込み
- ハードコードされた `/Users/yuya.matsushima/...` を `\$HOME` に置換し、他環境でも動作するよう調整
- `[ -n "\$ZSH_PROFILE" ] && zprof | less` が最終行に来るよう PATH 追加を前に移動
- installer が残した余分な空行を整理

## Test plan
- [x] `zsh -n ~/.zshrc` で syntax エラーなし
- [x] `zsh -i -c` で PATH に `$HOME/.lmstudio/bin` と `$HOME/.local/bin` が含まれることを確認
- [x] `which lms` が `~/.lmstudio/bin/lms` を解決できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)