### PR TITLE
feat(skills): ~/.gemini/antigravity-cli/skills を ~/.agents/skills へ symlink

### DIFF
--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -4,18 +4,18 @@ set -e
 REPO="fillin-inc/internal-skills"
 SKILLS="agents-init code-review commit debug flow implement issue pr requirements spec spec-issue verify"
 
-# antigravity-cli は $HOME/.antigravity/skills を参照するため,
-# $HOME/.agents/skills への symlink を作成して共用する
+# antigravity-cli は Global 配置として $HOME/.gemini/antigravity-cli/skills を
+# 参照するため, $HOME/.agents/skills への symlink を作成して共用する
 link_antigravity_skills() {
     src="$HOME/.agents/skills"
-    dest="$HOME/.antigravity/skills"
+    dest="$HOME/.gemini/antigravity-cli/skills"
 
     if [ ! -d "$src" ]; then
         echo "skip antigravity link: $src does not exist"
         return
     fi
 
-    mkdir -p "$HOME/.antigravity"
+    mkdir -p "$HOME/.gemini/antigravity-cli"
 
     if [ -L "$dest" ]; then
         current="$(readlink "$dest")"
@@ -59,7 +59,7 @@ do_uninstall() {
     done
 
     # $HOME/.agents/skills を指す symlink のみ削除
-    antigravity_link="$HOME/.antigravity/skills"
+    antigravity_link="$HOME/.gemini/antigravity-cli/skills"
     if [ -L "$antigravity_link" ]; then
         current="$(readlink "$antigravity_link")"
         if [ "$current" = "$HOME/.agents/skills" ]; then

--- a/bin/install_skills.sh
+++ b/bin/install_skills.sh
@@ -4,6 +4,36 @@ set -e
 REPO="fillin-inc/internal-skills"
 SKILLS="agents-init code-review commit debug flow implement issue pr requirements spec spec-issue verify"
 
+# antigravity-cli は $HOME/.antigravity/skills を参照するため,
+# $HOME/.agents/skills への symlink を作成して共用する
+link_antigravity_skills() {
+    src="$HOME/.agents/skills"
+    dest="$HOME/.antigravity/skills"
+
+    if [ ! -d "$src" ]; then
+        echo "skip antigravity link: $src does not exist"
+        return
+    fi
+
+    mkdir -p "$HOME/.antigravity"
+
+    if [ -L "$dest" ]; then
+        current="$(readlink "$dest")"
+        if [ "$current" = "$src" ]; then
+            echo "antigravity link: $dest -> $src (already linked)"
+            return
+        fi
+        echo "antigravity link: replace existing symlink $dest -> $current"
+        rm "$dest"
+    elif [ -e "$dest" ]; then
+        echo "antigravity link: $dest exists and is not a symlink, skipping" >&2
+        return
+    fi
+
+    ln -s "$src" "$dest"
+    echo "antigravity link: $dest -> $src"
+}
+
 do_install() {
     for skill in $SKILLS; do
         # $HOME/.agents/skills に配置 (Codex / Copilot / Gemini CLI 等が共用)
@@ -11,6 +41,8 @@ do_install() {
         # $HOME/.claude/skills に配置 (Claude Code)
         gh skill install "$REPO" "$skill" --agent claude-code --scope user --force
     done
+
+    link_antigravity_skills
 }
 
 do_uninstall() {
@@ -25,10 +57,23 @@ do_uninstall() {
             fi
         done
     done
+
+    # $HOME/.agents/skills を指す symlink のみ削除
+    antigravity_link="$HOME/.antigravity/skills"
+    if [ -L "$antigravity_link" ]; then
+        current="$(readlink "$antigravity_link")"
+        if [ "$current" = "$HOME/.agents/skills" ]; then
+            echo "remove: $antigravity_link"
+            rm "$antigravity_link"
+        else
+            echo "keep: $antigravity_link -> $current (not managed)"
+        fi
+    fi
 }
 
 do_update() {
     gh skill update --all
+    link_antigravity_skills
 }
 
 CMD="${1:-install}"


### PR DESCRIPTION
## Summary
- antigravity-cli の Global skill ディレクトリ \`~/.gemini/antigravity-cli/skills\` を \`~/.agents/skills\` へ symlink する処理を \`bin/install_skills.sh\` の install / update に追加
- \`make skills_uninstall\` でも管理下の symlink のみクリーンアップ (他用途の symlink は保持)
- symlink 作成は冪等 (既存リンクが同じ src なら no-op, 異なる src なら張り直し, 通常ディレクトリが存在する場合は skip)

## Test plan
- [x] \`sh -n bin/install_skills.sh\` で文法チェック
- [x] \`shellcheck bin/install_skills.sh\` 無警告
- [x] 実環境で \`link_antigravity_skills\` を実行し \`~/.gemini/antigravity-cli/skills -> ~/.agents/skills\` が張られることを確認
- [x] 2 回連続実行で \`(already linked)\` となり冪等であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)