### PR TITLE
refactor: remove legacy antigravity-cli path config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,7 @@
 **/markdown/
 webdata-output/
 
+# Antigravity CLI
+.antigravitycli/
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,9 @@
 *.dylib
 .hammerspoon/hs/libspaces*dylib.dSYM/*
 
-# Claude Code
+# Coding Agent
 .claude
+.antigravitycli/
 
 # webdata-node dependencies
 .zsh/bin/webdata-node/node_modules/
@@ -26,8 +27,3 @@
 **/captures/
 **/markdown/
 webdata-output/
-
-# Antigravity CLI
-.antigravitycli/
-
-

--- a/.zshenv
+++ b/.zshenv
@@ -49,7 +49,6 @@ local add_path_dirs=(
   $HOMEBREW_PREFIX/opt/libpq/bin
   $HOME/.lmstudio/bin
   $HOME/.local/bin
-  $HOME/.antigravity/antigravity/bin
   ${ASDF_DATA_DIR:-$HOME/.asdf}/shims
 )
 # Add GOPATH/bin only if GOPATH is defined

--- a/_.gitignore
+++ b/_.gitignore
@@ -32,5 +32,3 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
-
-

--- a/_.gitignore
+++ b/_.gitignore
@@ -32,3 +32,7 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# Antigravity CLI
+.antigravitycli/
+

--- a/_.gitignore
+++ b/_.gitignore
@@ -33,6 +33,4 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-# Antigravity CLI
-.antigravitycli/
 

--- a/bin/homebrew/app.sh
+++ b/bin/homebrew/app.sh
@@ -5,6 +5,7 @@ set -e
 brew install k1LoW/tap/mo
 
 brew install --cask \
+          antigravity-cli \
           docker \
           displayplacer \
           firefox \


### PR DESCRIPTION
既存の agy コマンド一式を Homebrew インストールへ移行することに伴い、不要になった古いパス設定（~/.antigravity/antigravity/bin）を .zshenv から削除しました。