### PR TITLE
feat(nvim): add markdown word/char count to lualine

### DIFF
--- a/.config/nvim/lua/plugins/ui.lua
+++ b/.config/nvim/lua/plugins/ui.lua
@@ -26,6 +26,15 @@ local function line_location()
   return '[' .. string.format('%d/%d', line, total) .. ']'
 end
 
+-- Markdown word/char count (visual selection takes precedence)
+local function md_count()
+  if vim.bo.filetype ~= 'markdown' then return '' end
+  local wc = vim.fn.wordcount()
+  local words = wc.visual_words or wc.words
+  local chars = wc.visual_chars or wc.chars
+  return string.format('[%dw/%dc]', words, chars)
+end
+
 -- File type without icon
 local function filetype_no_icon()
   return '[' .. vim.bo.filetype .. ']'
@@ -70,7 +79,8 @@ return {
           },
           -- Right side
           lualine_x = {
-            { line_location, padding = 0 },  -- Line/total (leftmost on right side)
+            { md_count, padding = 0 },  -- Markdown only: word/char count (leftmost on right side)
+            { line_location, padding = 0 },  -- Line/total
             { filetype_no_icon, padding = 0 },
             { encoding_bracketed, padding = 0 },
             { keyboard_type, padding = 0 },


### PR DESCRIPTION
## Summary
Markdown 編集時に lualine 右側へ単語数と文字数 `[Nw/Nc]` を表示する。

## Key Changes
- `.config/nvim/lua/plugins/ui.lua` に `md_count()` を追加（`filetype == markdown` のときのみ値を返す）
- `lualine_x` の最左に `md_count` を配置し、`line_location` の前に表示
- ビジュアル選択中は `wordcount().visual_words / visual_chars` を優先

## Impact
- Markdown 以外のファイルでは空文字を返すため既存表示に影響なし
- `wordcount()` の word は空白区切りで日本語では実用性が低いが、英語ドキュメント用に併記として残している
