### PR TITLE
fix(ghostty): close 系キーバインドを無効化し誤爆を防止

### DIFF
--- a/.config/ghostty/config
+++ b/.config/ghostty/config
@@ -46,6 +46,11 @@ window-new-tab-position = end
 # Keybindings
 keybind = super+n=new_tab
 keybind = super+q=ignore
+# 誤爆防止: close 系ショートカットを全て無効化し, window の close ボタンのみで閉じる
+keybind = super+w=ignore
+keybind = super+alt+w=ignore
+keybind = super+shift+w=ignore
+keybind = super+alt+shift+w=ignore
 
 # Others
 mouse-hide-while-typing = true


### PR DESCRIPTION
## Summary
Mac で Ghostty 使用中に意図せず window/tab を閉じてしまう誤爆を防ぐため, キーボード経由の close 系ショートカットを全て無効化する。`confirm-close-surface = false` のため Cmd+W 等が確認なしで即閉じしていたのが原因。

## Key Changes
- `.config/ghostty/config` の Keybindings に以下を追加:
  - `super+w=ignore` (close_surface)
  - `super+alt+w=ignore` (close_tab:this)
  - `super+shift+w=ignore` (close_window)
  - `super+alt+shift+w=ignore` (close_all_windows)
- window の close ボタンでのみ閉じる運用に統一（`super+q=ignore` は従来どおり維持）

## Impact
- キーボードによる tab/split/window のクローズ操作が一切できなくなる。閉じる手段は window の close ボタンのみ。
- `~/.config/ghostty` は symlink のため反映には Ghostty の `reload_config` (Cmd+Shift+,) もしくは再起動が必要。

## 検証
- `ghostty +list-keybinds` で 4 つの close 系が全て `ignore` に上書きされ, `close_surface` 等のデフォルト動作が消えていることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
