### PR TITLE
feat: project に internal-skill を追加する add-internal-skill 関数を新設

### DIFF
--- a/.zsh/functions/_add-internal-skill
+++ b/.zsh/functions/_add-internal-skill
@@ -1,0 +1,11 @@
+#compdef add-internal-skill
+
+# add-internal-skill の補完定義
+# skill 選択は fzf で行うため, 引数補完は -h/--help のみ。
+
+_add-internal-skill() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[print help]'
+}
+
+_add-internal-skill "$@"

--- a/.zsh/functions/add-internal-skill
+++ b/.zsh/functions/add-internal-skill
@@ -35,15 +35,8 @@ EOF
 # インストール元 (GitHub repository slug)
 local repo_slug="fillin-inc/internal-skills"
 
-# Check dependencies
-local _ymt_ais_cmd
-for _ymt_ais_cmd in fzf gh git; do
-  if ! command -v "$_ymt_ais_cmd" >/dev/null 2>&1; then
-    echo "Error: $_ymt_ais_cmd command not found. Please install $_ymt_ais_cmd." >&2
-    return 1
-  fi
-done
-
+# ヘルプ / 引数チェック (外部コマンド不要なので依存チェックより先に処理する。
+# fzf/gh/git 未導入の環境でも -h / --help が動くようにするため)
 case "${1:-}" in
   -h|--help|help)
     _ymt_ais_usage "$repo_slug"
@@ -57,6 +50,15 @@ case "${1:-}" in
     return 1
     ;;
 esac
+
+# Check dependencies
+local _ymt_ais_cmd
+for _ymt_ais_cmd in fzf gh git; do
+  if ! command -v "$_ymt_ais_cmd" >/dev/null 2>&1; then
+    echo "Error: $_ymt_ais_cmd command not found. Please install $_ymt_ais_cmd." >&2
+    return 1
+  fi
+done
 
 # project scope は git リポジトリのルートを基準にするため, repo 内での実行が前提
 local repo_root

--- a/.zsh/functions/add-internal-skill
+++ b/.zsh/functions/add-internal-skill
@@ -2,7 +2,10 @@
 
 # add-internal-skill: fillin-inc/internal-skills の skill を, 現在の git
 # リポジトリ (project scope) の .claude/skills と .agents/skills 両方へ追加する。
-# 未インストールの skill のみを fzf で複数選択し, gh skill install で配置する。
+#
+# 候補一覧・プレビュー・インストールをすべて GitHub の同一 ref (最新タグ) から
+# 解決するため, fzf に表示された skill は必ずインストールできる。ローカルに
+# internal-skills を clone している必要はない (ネットワーク接続が前提)。
 
 _ymt_ais_usage() {
   local repo="$1"
@@ -10,7 +13,9 @@ _ymt_ais_usage() {
 add-internal-skill installs ${repo} skills into the current git repository
 (project scope), placing each skill into both .claude/skills and .agents/skills.
 
-未インストールの skill のみが fzf に表示されます。複数選択 (Tab) して Enter で追加します。
+候補一覧・プレビュー・インストールはいずれも GitHub の ${repo} (最新タグ) を
+参照します。未インストールの skill のみが fzf に表示されます。複数選択 (Tab) して
+Enter で追加します。
 
 Usage:
   add-internal-skill          fzf で未インストール skill を複数選択して追加
@@ -19,27 +24,11 @@ Usage:
 Options:
   -h, --help                  print help
 
-Environment:
-  INTERNAL_SKILLS_DIR         利用可能な skill 一覧を読み取るローカルリポジトリのパス
-                              (既定: \$HOME/Project/fillin/internal-skills)
-
 Dependencies:
   fzf
-  gh
+  gh   (gh auth login 済みであること)
   git
 EOF
-}
-
-# 利用可能な skill 名を 1 行ずつ出力する。
-# gh skill に一覧コマンドが無いため, ローカルリポジトリの skills/*/SKILL.md を走査する。
-_ymt_ais_available() {
-  local repo="$1"
-  local d
-  for d in "$repo"/skills/*(/N); do
-    [[ -L "$d" ]] && continue
-    [[ -f "$d/SKILL.md" ]] || continue
-    print -- "${d:t}"
-  done
 }
 
 # インストール元 (GitHub repository slug)
@@ -76,11 +65,21 @@ if [[ -z "$repo_root" ]]; then
   return 1
 fi
 
-# 利用可能な skill 一覧の取得元 (ローカルリポジトリ)
-local skills_repo="${INTERNAL_SKILLS_DIR:-$HOME/Project/fillin/internal-skills}"
-if [[ ! -d "$skills_repo/skills" ]]; then
-  echo "Error: skills directory not found: $skills_repo/skills" >&2
-  echo "Set INTERNAL_SKILLS_DIR to the local $repo_slug checkout." >&2
+# gh skill install は「最新タグ → default branch HEAD」の順でバージョンを解決する。
+# 一覧・プレビュー・install を同じ ref に揃えるため, 最新タグを特定して明示的に pin
+# する。タグが無いリポジトリでは ref を指定せず, 全工程が default branch HEAD を参照する。
+local skill_ref
+skill_ref=$(gh api "repos/$repo_slug/tags" --jq '.[].name' 2>/dev/null | sort -V | tail -1)
+local ref_qs=""
+[[ -n "$skill_ref" ]] && ref_qs="?ref=$skill_ref"
+
+# 利用可能な skill 一覧をリモートから取得 (skills/*/ のディレクトリ名)
+local available
+if ! available=$(gh api "repos/$repo_slug/contents/skills$ref_qs" \
+                   --jq '.[] | select(.type=="dir") | .name' 2>&1); then
+  echo "Error: failed to list skills from $repo_slug." >&2
+  echo "  $available" >&2
+  echo "  gh auth status とネットワーク接続を確認してください。" >&2
   return 1
 fi
 
@@ -94,20 +93,20 @@ while IFS= read -r name; do
     continue
   fi
   candidates+=("$name")
-done < <(_ymt_ais_available "$skills_repo")
+done <<< "$available"
 
 if (( ${#candidates[@]} == 0 )); then
   echo "All available skills are already installed in this repository."
   return 0
 fi
 
-# fzf で複数選択 (プレビューに SKILL.md を表示)
+# fzf で複数選択 (プレビューは同一 ref の SKILL.md をリモート取得)
 local -a selected
 selected=(${(f)"$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
     --header='Tab で複数選択, Enter で追加 (Esc で中止)' \
-    --preview="cat $skills_repo/skills/{}/SKILL.md" \
+    --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/skills/{}/SKILL.md$ref_qs'" \
     --preview-window='right:60%:wrap'
 )"})
 
@@ -116,12 +115,18 @@ if (( ${#selected[@]} == 0 )); then
   return 0
 fi
 
-# インストール (各 skill を .claude/skills と .agents/skills 両方へ)
+# インストール (各 skill を .claude/skills と .agents/skills 両方へ, 一覧と同じ ref に pin)
+local -a pin_args=()
+[[ -n "$skill_ref" ]] && pin_args=(--pin "$skill_ref")
+
 local skill
 for skill in "${selected[@]}"; do
-  echo "install: $skill -> $repo_root/.claude/skills, $repo_root/.agents/skills"
-  gh skill install "$repo_slug" "$skill" --agent claude-code --scope project --force || return 1
-  gh skill install "$repo_slug" "$skill" --agent github-copilot --scope project --force || return 1
+  echo "install: $skill (${skill_ref:-HEAD}) -> $repo_root/.claude/skills, $repo_root/.agents/skills"
+  if ! gh skill install "$repo_slug" "$skill" --agent claude-code   --scope project --force "${pin_args[@]}" ||
+     ! gh skill install "$repo_slug" "$skill" --agent github-copilot --scope project --force "${pin_args[@]}"; then
+    echo "Error: failed to install '$skill'." >&2
+    return 1
+  fi
 done
 
 echo "Done: ${#selected[@]} skill(s) installed."

--- a/.zsh/functions/add-internal-skill
+++ b/.zsh/functions/add-internal-skill
@@ -1,0 +1,127 @@
+#!/bin/zsh
+
+# add-internal-skill: fillin-inc/internal-skills の skill を, 現在の git
+# リポジトリ (project scope) の .claude/skills と .agents/skills 両方へ追加する。
+# 未インストールの skill のみを fzf で複数選択し, gh skill install で配置する。
+
+_ymt_ais_usage() {
+  local repo="$1"
+  cat <<EOF
+add-internal-skill installs ${repo} skills into the current git repository
+(project scope), placing each skill into both .claude/skills and .agents/skills.
+
+未インストールの skill のみが fzf に表示されます。複数選択 (Tab) して Enter で追加します。
+
+Usage:
+  add-internal-skill          fzf で未インストール skill を複数選択して追加
+  add-internal-skill -h       print help
+
+Options:
+  -h, --help                  print help
+
+Environment:
+  INTERNAL_SKILLS_DIR         利用可能な skill 一覧を読み取るローカルリポジトリのパス
+                              (既定: \$HOME/Project/fillin/internal-skills)
+
+Dependencies:
+  fzf
+  gh
+  git
+EOF
+}
+
+# 利用可能な skill 名を 1 行ずつ出力する。
+# gh skill に一覧コマンドが無いため, ローカルリポジトリの skills/*/SKILL.md を走査する。
+_ymt_ais_available() {
+  local repo="$1"
+  local d
+  for d in "$repo"/skills/*(/N); do
+    [[ -L "$d" ]] && continue
+    [[ -f "$d/SKILL.md" ]] || continue
+    print -- "${d:t}"
+  done
+}
+
+# インストール元 (GitHub repository slug)
+local repo_slug="fillin-inc/internal-skills"
+
+# Check dependencies
+local _ymt_ais_cmd
+for _ymt_ais_cmd in fzf gh git; do
+  if ! command -v "$_ymt_ais_cmd" >/dev/null 2>&1; then
+    echo "Error: $_ymt_ais_cmd command not found. Please install $_ymt_ais_cmd." >&2
+    return 1
+  fi
+done
+
+case "${1:-}" in
+  -h|--help|help)
+    _ymt_ais_usage "$repo_slug"
+    return 0
+    ;;
+  "")
+    ;;
+  *)
+    echo "Error: unknown argument: $1" >&2
+    _ymt_ais_usage "$repo_slug" >&2
+    return 1
+    ;;
+esac
+
+# project scope は git リポジトリのルートを基準にするため, repo 内での実行が前提
+local repo_root
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -z "$repo_root" ]]; then
+  echo "Error: Not a git repository. add-internal-skill installs at project scope." >&2
+  return 1
+fi
+
+# 利用可能な skill 一覧の取得元 (ローカルリポジトリ)
+local skills_repo="${INTERNAL_SKILLS_DIR:-$HOME/Project/fillin/internal-skills}"
+if [[ ! -d "$skills_repo/skills" ]]; then
+  echo "Error: skills directory not found: $skills_repo/skills" >&2
+  echo "Set INTERNAL_SKILLS_DIR to the local $repo_slug checkout." >&2
+  return 1
+fi
+
+# 未インストール skill を抽出
+# (.claude/skills と .agents/skills の両方に存在するものを「済」として除外)
+local -a candidates
+local name
+while IFS= read -r name; do
+  [[ -n "$name" ]] || continue
+  if [[ -e "$repo_root/.claude/skills/$name" && -e "$repo_root/.agents/skills/$name" ]]; then
+    continue
+  fi
+  candidates+=("$name")
+done < <(_ymt_ais_available "$skills_repo")
+
+if (( ${#candidates[@]} == 0 )); then
+  echo "All available skills are already installed in this repository."
+  return 0
+fi
+
+# fzf で複数選択 (プレビューに SKILL.md を表示)
+local -a selected
+selected=(${(f)"$(
+  printf '%s\n' "${candidates[@]}" | fzf \
+    --multi \
+    --header='Tab で複数選択, Enter で追加 (Esc で中止)' \
+    --preview="cat $skills_repo/skills/{}/SKILL.md" \
+    --preview-window='right:60%:wrap'
+)"})
+
+if (( ${#selected[@]} == 0 )); then
+  echo "No skill selected. Nothing to do."
+  return 0
+fi
+
+# インストール (各 skill を .claude/skills と .agents/skills 両方へ)
+local skill
+for skill in "${selected[@]}"; do
+  echo "install: $skill -> $repo_root/.claude/skills, $repo_root/.agents/skills"
+  gh skill install "$repo_slug" "$skill" --agent claude-code --scope project --force || return 1
+  gh skill install "$repo_slug" "$skill" --agent github-copilot --scope project --force || return 1
+done
+
+echo "Done: ${#selected[@]} skill(s) installed."

--- a/.zsh/functions/add-internal-skill
+++ b/.zsh/functions/add-internal-skill
@@ -28,6 +28,7 @@ Dependencies:
   fzf
   gh   (gh auth login 済みであること)
   git
+  bat  (任意: あれば SKILL.md プレビューを syntax highlight)
 EOF
 }
 
@@ -100,13 +101,22 @@ if (( ${#candidates[@]} == 0 )); then
   return 0
 fi
 
+# プレビューア: bat があれば markdown を syntax highlight, 無ければ cat にフォールバック
+# (行折り返しは fzf の preview-window=wrap に任せるため bat 側は --wrap=never)
+local previewer
+if command -v bat >/dev/null 2>&1; then
+  previewer="bat --language=md --color=always --style=plain --paging=never --wrap=never"
+else
+  previewer="cat"
+fi
+
 # fzf で複数選択 (プレビューは同一 ref の SKILL.md をリモート取得)
 local -a selected
 selected=(${(f)"$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
     --header='Tab で複数選択, Enter で追加 (Esc で中止)' \
-    --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/skills/{}/SKILL.md$ref_qs'" \
+    --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/skills/{}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'
 )"})
 


### PR DESCRIPTION
## Summary
`fillin-inc/internal-skills` の skill を、現在の git リポジトリ（project scope）の `.claude/skills` と `.agents/skills` の両方へ追加する zsh 関数 `add-internal-skill` を新設します。プロジェクト単位で、未インストールの skill だけをその場で足せるようにするのが目的です。

既存の `make skills`（`bin/install_skills.sh`）は **user scope** へホワイトリストの skill を入れる仕組みで、特定プロジェクトへ個別追加する用途には向かなかったため、これを補完します。

## Key Changes
- `.zsh/functions/add-internal-skill` を追加
  - 利用可能な skill 一覧は **GitHub の `fillin-inc/internal-skills`** を Contents API（`gh api`）で取得（`skills/*/` のディレクトリ名）。ローカルに clone していなくても動作する（ネットワーク接続が前提）
  - **一覧・プレビュー・install をすべて同一 ref（最新タグ）に pin** する。`gh skill install` は「最新タグ → default branch HEAD」で版を解決するため、最新タグを解決して `--pin` で固定し、fzf に表示した skill が必ず install できる状態を保証する
  - カレント git リポジトリの `.claude/skills` と `.agents/skills` の **両方に既にある skill は候補から除外**
  - `fzf --multi` で未インストール skill を複数選択（プレビューに同一 ref の `SKILL.md` をリモート取得して表示）
  - `gh skill install <repo> <skill> --agent claude-code --scope project --force --pin <tag>` と `--agent github-copilot` の 2 コマンドで両ディレクトリへ配置
  - 依存（`fzf`/`gh`/`git`）・git リポジトリ外・一覧取得失敗 の各エラーを `>&2` に出して `return 1`
- `.zsh/functions/_add-internal-skill` を追加（`-h/--help` の補完）

## Impact
- `~/.zsh` がディレクトリごと symlink されているため、新ファイルは反映済み（`make link` 不要）。次回シェル起動時に autoload される。
- `project` scope での配置はカレント git リポジトリのルートが基準。関数は git リポジトリ外ではエラー終了する。
- 既存の `make skills`（user scope）には影響しない。

## 検証
- `zsh -n` 構文チェック / autoload 登録
- `-h`・不正引数・git リポジトリ外 の各エラー分岐
- リモート一覧取得（最新タグ `v0.4.5` 解決、23 skill 列挙）と「両 scope にある skill の除外」フィルタ
- `dig` を temp git リポジトリへ実 install し、`.claude/skills/dig` と `.agents/skills/dig` 両方へ pin=v0.4.5 で配置されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)