### PR TITLE
feat(zsh): 任意リポジトリ対応の add-skill 関数を追加

### DIFF
--- a/.zsh/functions/_add-skill
+++ b/.zsh/functions/_add-skill
@@ -1,0 +1,12 @@
+#compdef add-skill
+
+# add-skill の補完定義
+# skill 選択は fzf で行うため, 引数補完は -h/--help と repository (owner/repo) のみ。
+
+_add-skill() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[print help]' \
+    '1:repository (owner/repo):'
+}
+
+_add-skill "$@"

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -161,6 +161,29 @@ if (( ${#selected[@]} == 0 )); then
   return 0
 fi
 
+# 選択 skill 間の leaf 名衝突を検証する。
+# gh skill install は leaf 名 (skill ディレクトリ名) で install 先を決めるため,
+# category 違いで同名の skill (skills/aws/deploy と skills/gcp/deploy 等) を同時に
+# 選ぶと, 同じ .claude/skills/<leaf> / .agents/skills/<leaf> へ --force で上書き
+# される。並行実行では同一ディレクトリへの同時書き込みにもなり, 一方が黙って失われた
+# まま両方「成功」と報告されてしまう。これを防ぐためここで弾く。
+local -A leaf_seen
+local conflict=0
+for skill in "${selected[@]}"; do
+  leaf="${skill:t}"
+  if [[ -n "${leaf_seen[$leaf]:-}" ]]; then
+    echo "Error: skill name conflict on '$leaf': '${leaf_seen[$leaf]}' と '$skill'." >&2
+    echo "  両者は同じ install 先 (.claude/skills/$leaf, .agents/skills/$leaf) を共有するため同時にインストールできません。" >&2
+    conflict=1
+  else
+    leaf_seen[$leaf]="$skill"
+  fi
+done
+if (( conflict )); then
+  echo "  片方ずつ選び直して再実行してください。" >&2
+  return 1
+fi
+
 # インストール (各 skill を .claude/skills と .agents/skills 両方へ, 一覧と同じ ref に pin)。
 # skill 単位で並行ジョブを起動し, 出力混在を避けるため各ジョブのログは一時ファイルへ。
 local -a pin_args=()

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -1,0 +1,204 @@
+#!/bin/zsh
+
+# add-skill: 任意の GitHub リポジトリの skill を, 現在の git リポジトリ
+# (project scope) の .claude/skills と .agents/skills 両方へ追加する。
+#
+# 対象リポジトリは引数で指定する (省略時は対話入力)。リポジトリ内の skill が
+# flat な skills/<skill-name>/SKILL.md でも, ネストした
+# skills/<category>/<skill-name>/SKILL.md でも対応する。
+#
+# 候補一覧・プレビュー・インストールをすべて GitHub の同一 ref (最新タグ) から
+# 解決するため, fzf に表示された skill は必ずインストールできる。ローカルに
+# リポジトリを clone している必要はない (ネットワーク接続が前提)。
+#
+# 選択した skill は skill 単位で並行インストールするため, 複数選択時の所要時間を
+# 短縮できる (各ジョブ内では claude-code -> github-copilot を直列実行)。
+#
+# 注意: usage は heredoc ではなく print -r -- を使う。zsh native autoload では
+# ネスト関数内の heredoc が終端 (EOF) を取りこぼす既知の癖があるため。
+
+_ymt_as_usage() {
+  print -r -- 'add-skill installs skills from an arbitrary GitHub repository into the current
+git repository (project scope), placing each skill into both .claude/skills and
+.agents/skills.
+
+候補一覧・プレビュー・インストールはいずれも対象リポジトリの最新タグ (無ければ
+default branch HEAD) を参照します。flat な skills/<skill>/SKILL.md でも, ネスト
+した skills/<category>/<skill>/SKILL.md でも対応します。未インストールの skill
+のみが fzf に表示されます。複数選択 (Tab) して Enter で並行インストールします。
+
+Usage:
+  add-skill <owner/repo>      指定リポジトリの未インストール skill を fzf で選択して追加
+  add-skill                   対象リポジトリを対話入力してから選択
+  add-skill -h                print help
+
+Options:
+  -h, --help                  print help
+
+Dependencies:
+  fzf
+  gh   (gh auth login 済みであること)
+  git
+  bat  (任意: あれば SKILL.md プレビューを syntax highlight)'
+}
+
+# ヘルプ / 引数チェック (外部コマンド不要なので依存チェックより先に処理する。
+# fzf/gh/git 未導入の環境でも -h / --help が動くようにするため)
+local repo_slug=""
+case "${1:-}" in
+  -h|--help|help)
+    _ymt_as_usage
+    return 0
+    ;;
+  "")
+    ;;
+  -*)
+    echo "Error: unknown option: $1" >&2
+    _ymt_as_usage >&2
+    return 1
+    ;;
+  *)
+    repo_slug="$1"
+    ;;
+esac
+
+# Check dependencies
+local _ymt_as_cmd
+for _ymt_as_cmd in fzf gh git; do
+  if ! command -v "$_ymt_as_cmd" >/dev/null 2>&1; then
+    echo "Error: $_ymt_as_cmd command not found. Please install $_ymt_as_cmd." >&2
+    return 1
+  fi
+done
+
+# 対象リポジトリ (省略時は対話入力)
+if [[ -z "$repo_slug" ]]; then
+  read "repo_slug?Target repository (owner/repo): "
+fi
+if [[ "$repo_slug" != */* ]]; then
+  echo "Error: repository must be in 'owner/repo' format: ${repo_slug:-<empty>}" >&2
+  _ymt_as_usage >&2
+  return 1
+fi
+
+# project scope は git リポジトリのルートを基準にするため, repo 内での実行が前提
+local repo_root
+repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+if [[ -z "$repo_root" ]]; then
+  echo "Error: Not a git repository. add-skill installs at project scope." >&2
+  return 1
+fi
+
+# gh skill install は「最新タグ -> default branch HEAD」の順でバージョンを解決する。
+# 一覧・プレビュー・install を同じ ref に揃えるため, 最新タグを特定して明示的に pin
+# する。タグが無いリポジトリでは default branch を ref に使う (tree API は HEAD を
+# 解決できないため, ref は必ず具体名にする)。pin はタグがある場合のみ行う。
+local skill_ref ref
+skill_ref=$(gh api "repos/$repo_slug/tags" --jq '.[].name' 2>/dev/null | sort -V | tail -1)
+if [[ -n "$skill_ref" ]]; then
+  ref="$skill_ref"
+else
+  if ! ref=$(gh api "repos/$repo_slug" --jq '.default_branch' 2>&1); then
+    echo "Error: failed to resolve default branch of $repo_slug." >&2
+    echo "  $ref" >&2
+    echo "  リポジトリ名 / gh auth status / ネットワーク接続を確認してください。" >&2
+    return 1
+  fi
+fi
+local ref_qs="?ref=$ref"
+
+# 利用可能な skill 一覧をリモートから取得 (ネスト対応)。
+# git tree から skills/.../SKILL.md の blob を抽出し, skill のパスを得る。
+local available
+if ! available=$(gh api "repos/$repo_slug/git/trees/$ref?recursive=1" \
+                   --jq '.tree[] | select(.type=="blob" and (.path|test("^skills/.+/SKILL\\.md$"))) | .path' 2>&1); then
+  echo "Error: failed to list skills from $repo_slug." >&2
+  echo "  $available" >&2
+  echo "  gh auth status とネットワーク接続を確認してください。" >&2
+  return 1
+fi
+
+# 未インストール skill を抽出
+# (skill パスの leaf 名で .claude/skills と .agents/skills の両在を「済」として除外)
+local -a candidates
+local line skill_path leaf
+while IFS= read -r line; do
+  [[ -n "$line" ]] || continue
+  skill_path="${line%/SKILL.md}"
+  leaf="${skill_path:t}"
+  if [[ -e "$repo_root/.claude/skills/$leaf" && -e "$repo_root/.agents/skills/$leaf" ]]; then
+    continue
+  fi
+  candidates+=("$skill_path")
+done <<< "$available"
+
+if (( ${#candidates[@]} == 0 )); then
+  echo "No installable skills found in $repo_slug (all installed or none present)."
+  return 0
+fi
+
+# プレビューア: bat があれば markdown を syntax highlight, 無ければ cat にフォールバック
+# (行折り返しは fzf の preview-window=wrap に任せるため bat 側は --wrap=never)
+local previewer
+if command -v bat >/dev/null 2>&1; then
+  previewer="bat --language=md --color=always --style=plain --paging=never --wrap=never"
+else
+  previewer="cat"
+fi
+
+# fzf で複数選択 (プレビューは同一 ref の SKILL.md をリモート取得)
+local -a selected
+selected=(${(f)"$(
+  printf '%s\n' "${candidates[@]}" | fzf \
+    --multi \
+    --header='Tab で複数選択, Enter で追加 (Esc で中止)' \
+    --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{}/SKILL.md$ref_qs' | $previewer" \
+    --preview-window='right:60%:wrap'
+)"})
+
+if (( ${#selected[@]} == 0 )); then
+  echo "No skill selected. Nothing to do."
+  return 0
+fi
+
+# インストール (各 skill を .claude/skills と .agents/skills 両方へ, 一覧と同じ ref に pin)。
+# skill 単位で並行ジョブを起動し, 出力混在を避けるため各ジョブのログは一時ファイルへ。
+local -a pin_args=()
+[[ -n "$skill_ref" ]] && pin_args=(--pin "$skill_ref")
+
+local tmpdir
+tmpdir=$(mktemp -d) || { echo "Error: failed to create temp dir." >&2; return 1; }
+
+local -a pids=() jobs=()
+local skill i=1
+for skill in "${selected[@]}"; do
+  echo "install: $skill (${skill_ref:-$ref}) -> $repo_root/.claude/skills, $repo_root/.agents/skills"
+  {
+    gh skill install "$repo_slug" "$skill" --agent claude-code   --scope project --force "${pin_args[@]}" &&
+    gh skill install "$repo_slug" "$skill" --agent github-copilot --scope project --force "${pin_args[@]}"
+  } >"$tmpdir/$i.log" 2>&1 &
+  pids+=($!)
+  jobs+=("$skill")
+  ((i++))
+done
+
+# 各ジョブを回収して成否を集計 (zsh 配列は 1-indexed)
+local fail=0
+for i in {1..${#pids[@]}}; do
+  if wait "$pids[$i]"; then
+    echo "ok: $jobs[$i]"
+  else
+    echo "FAILED: $jobs[$i]" >&2
+    cat "$tmpdir/$i.log" >&2
+    fail=1
+  fi
+done
+
+rm -rf "$tmpdir"
+
+if (( fail )); then
+  echo "Error: some skills failed to install." >&2
+  return 1
+fi
+
+echo "Done: ${#selected[@]} skill(s) installed."


### PR DESCRIPTION
## 概要

既存の `add-internal-skill` (`fillin-inc/internal-skills` 固定) を汎用化した新コマンド `add-skill` を追加します。任意の GitHub リポジトリを対象に、skill を project scope (`.claude/skills` と `.agents/skills` 両方) へインストールできます。

## 機能

- **任意リポジトリ指定**: 位置引数 `add-skill owner/repo`。省略時は `read` で対話入力 (`owner/repo` 形式バリデーション付き)
- **ネスト構造対応**: `gh api .../git/trees/<ref>?recursive=1` で git tree を走査し `skills/.../SKILL.md` を抽出。flat (`skills/<skill>`) でもネスト (`skills/<category>/<skill>`) でも候補に表示
- **gh skill install 使用**: `--agent claude-code` → `.claude/skills/`、`--agent github-copilot` → `.agents/skills/` の両方へ project scope で配置
- **並行インストール**: 選択 skill ごとにバックグラウンドジョブを起動し `wait` で回収。各ジョブ内では claude-code → github-copilot を直列実行、ログは一時ファイルに分離して出力混在を回避
- **ref 解決**: 最新タグ (無ければ default branch) を特定し、一覧/プレビュー/install を同一 ref に揃えてタグがあれば pin
- **leaf 名衝突検出**: category 違いで同名 leaf を持つ skill の同時選択を検出してエラー停止 (silent な上書き喪失を防止)
- `_add-skill` 補完を併設 (`-h`/`--help` と `owner/repo` 補完)

## 検証

- `zsh -n` 構文チェック通過
- `-h` / 不正引数 (slash 無し・不明オプション・非 git リポジトリ) のエラー処理を確認
- 実リポジトリ `fillin-inc/internal-skills` で skill 列挙 (23 件)・leaf 名抽出・並行インストール (`commit`/`debug`/`spec` が両ディレクトリに配置) を確認
- インストール済み skill が候補から除外されることを確認
- leaf 名衝突検出ロジックを単体テスト (衝突あり/なし)
- cross-review (codex) で 1 件の指摘 (leaf 名衝突) を検出し修正済み

## 補足

zsh native autoload ではネスト関数内の heredoc が終端を取りこぼす癖があるため、usage 出力は `print -r --` を使用しています。自動読み込みは `.zshrc` の `fpath` + `autoload` + `compinit` 機構によりファイル配置だけで有効です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)