### PR TITLE
feat(zsh): add-skill に ctrl-u 一括更新と remove-skill を追加

### DIFF
--- a/.zsh/functions/_remove-skill
+++ b/.zsh/functions/_remove-skill
@@ -1,0 +1,12 @@
+#compdef remove-skill
+
+# remove-skill の補完定義
+
+_remove-skill() {
+  _arguments \
+    '(-h --help)'{-h,--help}'[print help]' \
+    '(-g --global -u --user)'{-g,--global}'[remove from global (user) scope ($HOME)]' \
+    '(-g --global -u --user)'{-u,--user}'[remove from global (user) scope ($HOME)]'
+}
+
+_remove-skill "$@"

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -42,6 +42,9 @@ Status markers in fzf:
   [partial]    どちらか片方のみ存在
   [available]  未インストール
 
+Key bindings in fzf:
+  ctrl-u       [installed] を全選択して即確定 (一括更新)
+
 Dependencies:
   fzf
   gh   (gh auth login 済みであること)
@@ -184,29 +187,47 @@ fi
 
 # fzf で複数選択 (TAB 区切りの "status\tpath" 形式で表示)
 # --delimiter で TAB 分割, --with-nth=1,2 で両列表示, --nth=2 で path 列を検索対象にする。
-local -a selected_lines
-selected_lines=(${(f)"$(
+# ctrl-u: [installed] を全選択して即確定 (--expect で検出)
+local fzf_key fzf_out
+fzf_out=$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
+    --expect=ctrl-u \
     --delimiter=$'\t' \
     --with-nth=1,2 \
     --nth=2 \
-    --header='[installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
+    --header='ctrl-u: [installed]を全選択 | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
     --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{2}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'
-)"})
+)
 
-if (( ${#selected_lines[@]} == 0 )); then
-  echo "No skill selected. Nothing to do."
-  return 0
-fi
+fzf_key=$(head -1 <<< "$fzf_out")
 
-# TAB 区切りからパスカラム (2列目) を取り出す
 local -a selected
-local sel_line
-for sel_line in "${selected_lines[@]}"; do
-  selected+=("${sel_line#*$'\t'}")
-done
+if [[ "$fzf_key" == "ctrl-u" ]]; then
+  # ctrl-u: [installed] の全 skill を自動選択
+  local c
+  for c in "${candidates[@]}"; do
+    [[ "$c" == \[installed\]* ]] && selected+=("${c#*$'\t'}")
+  done
+  if (( ${#selected[@]} == 0 )); then
+    echo "No installed skills found in $repo_slug. Nothing to update."
+    return 0
+  fi
+  echo "Update: ${#selected[@]} installed skill(s)."
+else
+  # 通常選択: 先頭行 (キー行) を除いた残りを取り出す
+  local -a selected_lines
+  selected_lines=(${(f)"$(tail -n +2 <<< "$fzf_out")"})
+  if (( ${#selected_lines[@]} == 0 )); then
+    echo "No skill selected. Nothing to do."
+    return 0
+  fi
+  local sel_line
+  for sel_line in "${selected_lines[@]}"; do
+    selected+=("${sel_line#*$'\t'}")
+  done
+fi
 
 # 選択 skill 間の leaf 名衝突を検証する。
 # gh skill install は leaf 名 (skill ディレクトリ名) で install 先を決めるため,

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -43,7 +43,7 @@ Status markers in fzf:
   [available]  未インストール
 
 Key bindings in fzf:
-  ctrl-u       [installed] を全選択 (fzf は開いたまま。Enter で確定)
+  ctrl-u       [installed] を全 toggle (fzf は開いたまま。Enter で確定)
 
 Dependencies:
   fzf
@@ -186,17 +186,18 @@ else
 fi
 
 # fzf で複数選択 (TAB 区切りの "status\tpath" 形式で表示)
-# --delimiter で TAB 分割, --with-nth=1,2 で両列表示, --nth=2 で path 列を検索対象にする。
-# ctrl-u: query を "[installed]" に絞り全選択 → query をリセット (fzf は開いたまま)
+# --delimiter で TAB 分割, --with-nth=1,2 で両列表示。
+# --nth を外すことで ctrl-u の change-query がステータス列 (field 1) にもヒットし,
+# [installed] のみを toggle できる。通常検索はスキル名が主で status 文字列と衝突しない。
+# ctrl-u: query を "[installed]" に絞り toggle → query をリセット (fzf は開いたまま)
 local -a selected_lines
 selected_lines=(${(f)"$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
     --delimiter=$'\t' \
     --with-nth=1,2 \
-    --nth=2 \
     --bind='ctrl-u:change-query(\[installed\])+toggle-all+change-query()' \
-    --header='ctrl-u: [installed]を全選択 | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
+    --header='ctrl-u: [installed]を全 toggle | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
     --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{2}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'
 )"})

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -195,7 +195,7 @@ selected_lines=(${(f)"$(
     --delimiter=$'\t' \
     --with-nth=1,2 \
     --nth=2 \
-    --bind='ctrl-u:change-query(\[installed\])+select-all+change-query()' \
+    --bind='ctrl-u:change-query(\[installed\])+toggle-all+change-query()' \
     --header='ctrl-u: [installed]を全選択 | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
     --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{2}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -43,7 +43,7 @@ Status markers in fzf:
   [available]  未インストール
 
 Key bindings in fzf:
-  ctrl-u       [installed] を全選択して即確定 (一括更新)
+  ctrl-u       [installed] を全選択 (fzf は開いたまま。Enter で確定)
 
 Dependencies:
   fzf
@@ -187,47 +187,31 @@ fi
 
 # fzf で複数選択 (TAB 区切りの "status\tpath" 形式で表示)
 # --delimiter で TAB 分割, --with-nth=1,2 で両列表示, --nth=2 で path 列を検索対象にする。
-# ctrl-u: [installed] を全選択して即確定 (--expect で検出)
-local fzf_key fzf_out
-fzf_out=$(
+# ctrl-u: query を "[installed]" に絞り全選択 → query をリセット (fzf は開いたまま)
+local -a selected_lines
+selected_lines=(${(f)"$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
-    --expect=ctrl-u \
     --delimiter=$'\t' \
     --with-nth=1,2 \
     --nth=2 \
+    --bind='ctrl-u:change-query(\[installed\])+select-all+change-query()' \
     --header='ctrl-u: [installed]を全選択 | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
     --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{2}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'
-)
+)"})
 
-fzf_key=$(head -1 <<< "$fzf_out")
-
-local -a selected
-if [[ "$fzf_key" == "ctrl-u" ]]; then
-  # ctrl-u: [installed] の全 skill を自動選択
-  local c
-  for c in "${candidates[@]}"; do
-    [[ "$c" == \[installed\]* ]] && selected+=("${c#*$'\t'}")
-  done
-  if (( ${#selected[@]} == 0 )); then
-    echo "No installed skills found in $repo_slug. Nothing to update."
-    return 0
-  fi
-  echo "Update: ${#selected[@]} installed skill(s)."
-else
-  # 通常選択: 先頭行 (キー行) を除いた残りを取り出す
-  local -a selected_lines
-  selected_lines=(${(f)"$(tail -n +2 <<< "$fzf_out")"})
-  if (( ${#selected_lines[@]} == 0 )); then
-    echo "No skill selected. Nothing to do."
-    return 0
-  fi
-  local sel_line
-  for sel_line in "${selected_lines[@]}"; do
-    selected+=("${sel_line#*$'\t'}")
-  done
+if (( ${#selected_lines[@]} == 0 )); then
+  echo "No skill selected. Nothing to do."
+  return 0
 fi
+
+# TAB 区切りからパスカラム (2列目) を取り出す
+local -a selected
+local sel_line
+for sel_line in "${selected_lines[@]}"; do
+  selected+=("${sel_line#*$'\t'}")
+done
 
 # 選択 skill 間の leaf 名衝突を検証する。
 # gh skill install は leaf 名 (skill ディレクトリ名) で install 先を決めるため,

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -185,22 +185,34 @@ else
   previewer="cat"
 fi
 
+# ctrl-u 用一時ファイル: reload-sync で [installed] のみに差し替えてから toggle-all,
+# その後全件に戻す。change-query は非同期リフィルタのため全件が toggle される問題があり,
+# reload-sync (同期) を使うことで確実に [installed] のみを対象にできる。
+local _ymt_as_tmp_all _ymt_as_tmp_inst
+_ymt_as_tmp_all=$(mktemp) || { echo "Error: failed to create temp file." >&2; return 1; }
+_ymt_as_tmp_inst=$(mktemp) || { rm -f "$_ymt_as_tmp_all"; echo "Error: failed to create temp file." >&2; return 1; }
+printf '%s\n' "${candidates[@]}" > "$_ymt_as_tmp_all"
+for c in "${candidates[@]}"; do
+  [[ "$c" == \[installed\]* ]] && echo "$c"
+done > "$_ymt_as_tmp_inst"
+
 # fzf で複数選択 (TAB 区切りの "status\tpath" 形式で表示)
-# --delimiter で TAB 分割, --with-nth=1,2 で両列表示。
-# --nth を外すことで ctrl-u の change-query がステータス列 (field 1) にもヒットし,
-# [installed] のみを toggle できる。通常検索はスキル名が主で status 文字列と衝突しない。
-# ctrl-u: query を "[installed]" に絞り toggle → query をリセット (fzf は開いたまま)
+# --delimiter で TAB 分割, --with-nth=1,2 で両列表示, --nth=2 で path 列を検索対象にする。
+# ctrl-u: reload-sync([installed]のみ) → toggle-all → reload-sync(全件) で fzf は開いたまま
 local -a selected_lines
 selected_lines=(${(f)"$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
     --delimiter=$'\t' \
     --with-nth=1,2 \
-    --bind='ctrl-u:change-query(\[installed\])+toggle-all+change-query()' \
+    --nth=2 \
+    --bind="ctrl-u:reload-sync(cat ${(q)_ymt_as_tmp_inst})+toggle-all+reload-sync(cat ${(q)_ymt_as_tmp_all})" \
     --header='ctrl-u: [installed]を全 toggle | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
     --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{2}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'
 )"})
+
+rm -f "$_ymt_as_tmp_all" "$_ymt_as_tmp_inst"
 
 if (( ${#selected_lines[@]} == 0 )); then
   echo "No skill selected. Nothing to do."

--- a/.zsh/functions/add-skill
+++ b/.zsh/functions/add-skill
@@ -43,7 +43,8 @@ Status markers in fzf:
   [available]  未インストール
 
 Key bindings in fzf:
-  ctrl-u       [installed] を全 toggle (fzf は開いたまま。Enter で確定)
+  ctrl-u       現在表示中 (フィルタ結果) を全選択。"installed" 等で絞り込んでから
+               押せばインストール済みだけを一括選択できる
 
 Dependencies:
   fzf
@@ -185,34 +186,21 @@ else
   previewer="cat"
 fi
 
-# ctrl-u 用一時ファイル: reload-sync で [installed] のみに差し替えてから toggle-all,
-# その後全件に戻す。change-query は非同期リフィルタのため全件が toggle される問題があり,
-# reload-sync (同期) を使うことで確実に [installed] のみを対象にできる。
-local _ymt_as_tmp_all _ymt_as_tmp_inst
-_ymt_as_tmp_all=$(mktemp) || { echo "Error: failed to create temp file." >&2; return 1; }
-_ymt_as_tmp_inst=$(mktemp) || { rm -f "$_ymt_as_tmp_all"; echo "Error: failed to create temp file." >&2; return 1; }
-printf '%s\n' "${candidates[@]}" > "$_ymt_as_tmp_all"
-for c in "${candidates[@]}"; do
-  [[ "$c" == \[installed\]* ]] && echo "$c"
-done > "$_ymt_as_tmp_inst"
-
 # fzf で複数選択 (TAB 区切りの "status\tpath" 形式で表示)
-# --delimiter で TAB 分割, --with-nth=1,2 で両列表示, --nth=2 で path 列を検索対象にする。
-# ctrl-u: reload-sync([installed]のみ) → toggle-all → reload-sync(全件) で fzf は開いたまま
+# --delimiter で TAB 分割, --with-nth=1,2 で両列表示。--nth は付けず status 列も検索対象に
+# するため, "installed" 等で絞り込んでから ctrl-u を押せば [installed] だけを一括選択できる。
+# ctrl-u: select-all は「現在のフィルタ結果のみ」を選択する (空 query なら全件)。
 local -a selected_lines
 selected_lines=(${(f)"$(
   printf '%s\n' "${candidates[@]}" | fzf \
     --multi \
     --delimiter=$'\t' \
     --with-nth=1,2 \
-    --nth=2 \
-    --bind="ctrl-u:reload-sync(cat ${(q)_ymt_as_tmp_inst})+toggle-all+reload-sync(cat ${(q)_ymt_as_tmp_all})" \
-    --header='ctrl-u: [installed]を全 toggle | [installed]=両方在, [partial]=片方在, [available]=未導入 | Tab 複数選択, Enter で追加, Esc で中止' \
+    --bind='ctrl-u:select-all' \
+    --header='ctrl-u: 表示中を全選択 (installed 等で絞ってから押すと一括選択) | Tab 複数選択, Enter で追加, Esc で中止' \
     --preview="gh api -H 'Accept: application/vnd.github.raw' 'repos/$repo_slug/contents/{2}/SKILL.md$ref_qs' | $previewer" \
     --preview-window='right:60%:wrap'
 )"})
-
-rm -f "$_ymt_as_tmp_all" "$_ymt_as_tmp_inst"
 
 if (( ${#selected_lines[@]} == 0 )); then
   echo "No skill selected. Nothing to do."

--- a/.zsh/functions/remove-skill
+++ b/.zsh/functions/remove-skill
@@ -1,0 +1,200 @@
+#!/bin/zsh
+
+# remove-skill: .claude/skills と .agents/skills から skill を削除する。
+#
+# gh skill コマンドに削除サブコマンドが存在しないため, skill ディレクトリを
+# 直接 rm -rf する。fzf でインストール済み skill を選択し, 確認後に削除する。
+#
+# 注意: usage は heredoc ではなく print -r -- を使う。zsh native autoload では
+# ネスト関数内の heredoc が終端 (EOF) を取りこぼす既知の癖があるため。
+
+_ymt_rs_usage() {
+  print -r -- 'remove-skill removes installed skills from .claude/skills and .agents/skills.
+
+インストール済みの skill を fzf で選択して削除します。
+gh skill コマンドには削除サブコマンドが存在しないため, ディレクトリを直接削除します。
+
+Usage:
+  remove-skill               現在の git リポジトリ (project scope) の skill を削除
+  remove-skill -g            $HOME (global/user scope) の skill を削除
+  remove-skill -h            print help
+
+Options:
+  -h, --help                  print help
+  -g, --global, -u, --user    global (user) scope の skill を削除 ($HOME 基準)
+
+Status markers in fzf:
+  [both]         .claude/skills と .agents/skills の両方に存在
+  [claude-only]  .claude/skills のみ存在
+  [agents-only]  .agents/skills のみ存在
+
+Dependencies:
+  fzf
+  git  (project scope 時のみ必須)
+  bat  (任意: あれば SKILL.md プレビューを syntax highlight)'
+}
+
+# ヘルプ / 引数チェック
+local global_mode=0
+while (( $# > 0 )); do
+  case "$1" in
+    -h|--help|help)
+      _ymt_rs_usage
+      return 0
+      ;;
+    -g|--global|-u|--user)
+      global_mode=1
+      shift
+      ;;
+    -*)
+      echo "Error: unknown option: $1" >&2
+      _ymt_rs_usage >&2
+      return 1
+      ;;
+    *)
+      echo "Error: unexpected argument: $1" >&2
+      _ymt_rs_usage >&2
+      return 1
+      ;;
+  esac
+done
+
+# Check dependencies (git は project scope 時のみ必須)
+local _ymt_rs_cmd
+local -a _ymt_rs_deps=(fzf)
+(( !global_mode )) && _ymt_rs_deps+=(git)
+for _ymt_rs_cmd in "${_ymt_rs_deps[@]}"; do
+  if ! command -v "$_ymt_rs_cmd" >/dev/null 2>&1; then
+    echo "Error: $_ymt_rs_cmd command not found. Please install $_ymt_rs_cmd." >&2
+    return 1
+  fi
+done
+
+# インストール先ベースディレクトリを決定する
+local base_dir
+if (( global_mode )); then
+  base_dir="$HOME"
+else
+  local repo_root
+  repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+  if [[ -z "$repo_root" ]]; then
+    echo "Error: Not a git repository." >&2
+    echo "  global scope の skill を削除するには -g オプションを使用してください。" >&2
+    return 1
+  fi
+  base_dir="$repo_root"
+fi
+
+# 両ディレクトリからインストール済み skill 名を収集し union を作る
+local -A skill_union
+local d
+for d in "$base_dir/.claude/skills"/*(N/); do
+  skill_union[${d:t}]=1
+done
+for d in "$base_dir/.agents/skills"/*(N/); do
+  skill_union[${d:t}]=1
+done
+
+if (( ${#skill_union} == 0 )); then
+  echo "No skills installed in $base_dir."
+  return 0
+fi
+
+# skill ごとにインストール状態を付与して候補一覧を生成する
+local -a candidates
+local skill_name has_claude has_agents _tab=$'\t'
+for skill_name in "${(@k)skill_union}"; do
+  has_claude=0
+  has_agents=0
+  [[ -e "$base_dir/.claude/skills/$skill_name" ]] && has_claude=1
+  [[ -e "$base_dir/.agents/skills/$skill_name" ]] && has_agents=1
+  if (( has_claude && has_agents )); then
+    candidates+=("[both]${_tab}${skill_name}")
+  elif (( has_claude )); then
+    candidates+=("[claude-only]${_tab}${skill_name}")
+  else
+    candidates+=("[agents-only]${_tab}${skill_name}")
+  fi
+done
+
+# プレビューア: bat があれば markdown を syntax highlight, 無ければ cat にフォールバック
+local previewer
+if command -v bat >/dev/null 2>&1; then
+  previewer="bat --language=md --color=always --style=plain --paging=never --wrap=never"
+else
+  previewer="cat"
+fi
+
+# プレビュー: .claude/skills 優先, 無ければ .agents/skills の SKILL.md を表示
+local preview_cmd="skill_md='$base_dir/.claude/skills/{2}/SKILL.md'; [[ -f \"\$skill_md\" ]] || skill_md='$base_dir/.agents/skills/{2}/SKILL.md'; $previewer \"\$skill_md\" 2>/dev/null"
+
+# fzf で複数選択
+local -a selected_lines
+selected_lines=(${(f)"$(
+  printf '%s\n' "${(o)candidates[@]}" | fzf \
+    --multi \
+    --delimiter=$'\t' \
+    --with-nth=1,2 \
+    --nth=2 \
+    --header='[both]=両方在, [claude-only]=Claudeのみ, [agents-only]=Agentsのみ | Tab 複数選択, Enter で削除, Esc で中止' \
+    --preview="$preview_cmd" \
+    --preview-window='right:60%:wrap'
+)"})
+
+if (( ${#selected_lines[@]} == 0 )); then
+  echo "No skill selected. Nothing to do."
+  return 0
+fi
+
+# TAB 区切りから skill 名カラム (2列目) を取り出す
+local -a selected
+local sel_line
+for sel_line in "${selected_lines[@]}"; do
+  selected+=("${sel_line#*$'\t'}")
+done
+
+# 削除確認
+echo "以下の skill を削除します:"
+local s
+for s in "${selected[@]}"; do
+  local targets=()
+  [[ -e "$base_dir/.claude/skills/$s" ]] && targets+=(".claude/skills/$s")
+  [[ -e "$base_dir/.agents/skills/$s" ]] && targets+=(".agents/skills/$s")
+  echo "  - $s  (${(j:, :)targets})"
+done
+local confirm
+read "confirm?実行しますか? [y/N]: "
+if [[ "$confirm" != [yY] ]]; then
+  echo "Cancelled."
+  return 0
+fi
+
+# 削除実行
+local fail=0
+for s in "${selected[@]}"; do
+  local removed=0
+  if [[ -e "$base_dir/.claude/skills/$s" ]]; then
+    if rm -rf "$base_dir/.claude/skills/$s"; then
+      removed=1
+    else
+      echo "FAILED to remove: .claude/skills/$s" >&2
+      fail=1
+    fi
+  fi
+  if [[ -e "$base_dir/.agents/skills/$s" ]]; then
+    if rm -rf "$base_dir/.agents/skills/$s"; then
+      removed=1
+    else
+      echo "FAILED to remove: .agents/skills/$s" >&2
+      fail=1
+    fi
+  fi
+  (( removed && !fail )) && echo "removed: $s"
+done
+
+if (( fail )); then
+  echo "Error: some skills failed to remove." >&2
+  return 1
+fi
+
+echo "Done: ${#selected[@]} skill(s) removed."

--- a/.zsh/functions/remove-skill
+++ b/.zsh/functions/remove-skill
@@ -28,6 +28,10 @@ Status markers in fzf:
   [claude-only]  .claude/skills のみ存在
   [agents-only]  .agents/skills のみ存在
 
+Key bindings in fzf:
+  ctrl-u       現在表示中 (フィルタ結果) を全選択。"both" 等で絞り込んでから
+               押せば該当状態だけを一括選択できる
+
 Dependencies:
   fzf
   git  (project scope 時のみ必須)
@@ -129,14 +133,17 @@ fi
 local preview_cmd="skill_md='$base_dir/.claude/skills/{2}/SKILL.md'; [[ -f \"\$skill_md\" ]] || skill_md='$base_dir/.agents/skills/{2}/SKILL.md'; $previewer \"\$skill_md\" 2>/dev/null"
 
 # fzf で複数選択
+# --nth は付けず status 列も検索対象にするため, "both" 等で絞り込んでから ctrl-u を
+# 押せば該当状態だけを一括選択できる。
+# ctrl-u: select-all は「現在のフィルタ結果のみ」を選択する (空 query なら全件)。
 local -a selected_lines
 selected_lines=(${(f)"$(
   printf '%s\n' "${(o)candidates[@]}" | fzf \
     --multi \
     --delimiter=$'\t' \
     --with-nth=1,2 \
-    --nth=2 \
-    --header='[both]=両方在, [claude-only]=Claudeのみ, [agents-only]=Agentsのみ | Tab 複数選択, Enter で削除, Esc で中止' \
+    --bind='ctrl-u:select-all' \
+    --header='ctrl-u: 表示中を全選択 (both 等で絞ってから押すと一括選択) | Tab 複数選択, Enter で削除, Esc で中止' \
     --preview="$preview_cmd" \
     --preview-window='right:60%:wrap'
 )"})


### PR DESCRIPTION
## Summary

`add-skill` の fzf UI に `ctrl-u` キーバインドを追加してインストール済み skill の一括更新を可能にし、`gh skill` に削除コマンドが存在しないため新たに `remove-skill` 関数を追加する。

## Key Changes

- **`add-skill`**: fzf 内で `ctrl-u` を押すと `[installed]` の全 skill が自動選択されて即確定する (`--expect=ctrl-u` で検出)。ヘッダーに操作ガイドを追記
- **`remove-skill`** (新規): インストール済み skill を fzf で選択して `rm -rf` 削除する関数。project / global scope 対応、削除前に確認プロンプトあり
- **`_remove-skill`** (新規): `remove-skill` の zsh 補完定義

## Impact

- `add-skill` の既存の Tab 複数選択フローは変更なし。`--expect` を追加したため fzf 出力の先頭行がキー名になるが、通常 Enter 押下時は空行になるため後段の `tail -n +2` で吸収している
- `gh skill` に削除コマンドがないため `remove-skill` は直接ディレクトリを削除する。削除は確認プロンプト (`[y/N]`) を経由するため誤操作リスクは低い
