### PR TITLE
fix(zsh): skill install 後にスクリプトの実行権限を復元

### DIFF
--- a/.zsh/functions/skill
+++ b/.zsh/functions/skill
@@ -139,6 +139,20 @@ Dependencies:
   bat  (任意: あれば SKILL.md プレビューを syntax highlight)'
 }
 
+# gh skill install は GitHub API 経由でファイルを取得するため exec bit を保持しない。
+# インストール後に shebang (#!) を持つファイルへ実行権限を復元するヘルパー。
+# 引数はインストール先 skill ディレクトリ (存在しない場合は何もしない)。
+_ymt_skill_restore_exec() {
+    local dir="$1"
+    [[ -d "$dir" ]] || return 0
+    local f first
+    find "$dir" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
+        IFS= read -r first < "$f" 2>/dev/null || continue
+        [[ "$first" == '#!'* ]] && chmod u+x "$f"
+    done
+    return 0
+}
+
 # add サブコマンド本体
 _ymt_skill_add() {
   # ヘルプ / 引数チェック (外部コマンド不要なので依存チェックより先に処理する。
@@ -339,16 +353,21 @@ _ymt_skill_add() {
   local -a pids=() jobs=()
   local skill i=1
   for skill in "${selected[@]}"; do
+    local _leaf="${skill:t}"
     echo "install: $skill (${skill_ref:-$ref}) -> $base_dir/.claude/skills, $base_dir/.agents/skills"
     if (( global_mode )); then
       {
         gh skill install "$repo_slug" "$skill" --agent claude-code --scope user --force "${pin_args[@]}" &&
-        gh skill install "$repo_slug" "$skill" --dir "$HOME/.agents/skills" --agent github-copilot --force "${pin_args[@]}"
+        gh skill install "$repo_slug" "$skill" --dir "$HOME/.agents/skills" --agent github-copilot --force "${pin_args[@]}" &&
+        _ymt_skill_restore_exec "$base_dir/.claude/skills/$_leaf" &&
+        _ymt_skill_restore_exec "$base_dir/.agents/skills/$_leaf"
       } >"$tmpdir/$i.log" 2>&1 &
     else
       {
         gh skill install "$repo_slug" "$skill" --agent claude-code   --scope project --force "${pin_args[@]}" &&
-        gh skill install "$repo_slug" "$skill" --agent github-copilot --scope project --force "${pin_args[@]}"
+        gh skill install "$repo_slug" "$skill" --agent github-copilot --scope project --force "${pin_args[@]}" &&
+        _ymt_skill_restore_exec "$base_dir/.claude/skills/$_leaf" &&
+        _ymt_skill_restore_exec "$base_dir/.agents/skills/$_leaf"
       } >"$tmpdir/$i.log" 2>&1 &
     fi
     pids+=($!)
@@ -648,18 +667,23 @@ _ymt_skill_update() {
     repo="${upd_repos[$i]}"
     sk_path="${upd_paths[$i]}"
     ref="${upd_refs[$i]}"
+    leaf="${sk_path:t}"
     local -a pin_args=()
     [[ -n "$ref" ]] && pin_args=(--pin "$ref")
     echo "update: ${upd_names[$i]} (${ref:-HEAD}) <- $repo/$sk_path"
     if (( global_mode )); then
       {
         gh skill install "$repo" "$sk_path" --agent claude-code --scope user --force "${pin_args[@]}" &&
-        gh skill install "$repo" "$sk_path" --dir "$HOME/.agents/skills" --agent github-copilot --force "${pin_args[@]}"
+        gh skill install "$repo" "$sk_path" --dir "$HOME/.agents/skills" --agent github-copilot --force "${pin_args[@]}" &&
+        _ymt_skill_restore_exec "$base_dir/.claude/skills/$leaf" &&
+        _ymt_skill_restore_exec "$base_dir/.agents/skills/$leaf"
       } >"$tmpdir/$i.log" 2>&1 &
     else
       {
         gh skill install "$repo" "$sk_path" --agent claude-code   --scope project --force "${pin_args[@]}" &&
-        gh skill install "$repo" "$sk_path" --agent github-copilot --scope project --force "${pin_args[@]}"
+        gh skill install "$repo" "$sk_path" --agent github-copilot --scope project --force "${pin_args[@]}" &&
+        _ymt_skill_restore_exec "$base_dir/.claude/skills/$leaf" &&
+        _ymt_skill_restore_exec "$base_dir/.agents/skills/$leaf"
       } >"$tmpdir/$i.log" 2>&1 &
     fi
     pids+=($!)


### PR DESCRIPTION
## 背景 / 問題

`skill add` / `skill update` 実行後、インストールされた skill (とくに `fillin/internal-skills`) 内のシェルスクリプトが「権限不足 (Permission denied)」で実行エラーになる問題が発生していた。

### 根本原因

`skill` コマンド (`.zsh/functions/skill`) は内部で `gh skill install` を呼んで skill を取得している。`gh skill install` は GitHub API 経由でファイルを取得するため **exec bit を保持しない**。その結果、ソースリポジトリで `755` (実行権限あり) のスクリプトがインストール後に `644` (実行権限なし) に落ち、skill 内部が `./scripts/foo.sh` のように直接実行するスクリプトが失敗していた。

実例 (インストール済み visualize-skill):
- ソース: `-rwxr-xr-x scripts/parse-args.sh`
- インストール後: `-rw-r--r-- scripts/parse-args.sh`

## 修正

- ヘルパー関数 `_ymt_skill_restore_exec` を追加。インストール先ディレクトリを再帰走査し、shebang (`#!`) で始まるファイルにのみ `chmod u+x` を適用する。
- `_ymt_skill_add` / `_ymt_skill_update` の並行インストールジョブで、両方の `gh skill install` 成功後に `.claude/skills/<leaf>` と `.agents/skills/<leaf>` へヘルパーを呼ぶよう変更 (project / global 両 scope に対応)。

## 検証

- `zsh -n .zsh/functions/skill` 構文チェック OK
- 実インストール済み skill での機能テスト: shebang を持つスクリプト (`.sh`, `validate-mermaid.sh`) のみ実行権限が復元され、`.md` 等の非スクリプトは `-rw-r--r--` のまま変化なしを確認

## 補足

- 本修正は今後の `skill add` / `skill update` に適用される。既にインストール済みの skill は次回 update 時に直る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)