### PR TITLE
fix(zsh): skill install 後の exec 復元を *.sh ベースに変更

### DIFF
--- a/.zsh/functions/skill
+++ b/.zsh/functions/skill
@@ -140,16 +140,12 @@ Dependencies:
 }
 
 # gh skill install は GitHub API 経由でファイルを取得するため exec bit を保持しない。
-# インストール後に shebang (#!) を持つファイルへ実行権限を復元するヘルパー。
+# インストール後に *.sh ファイルへ実行権限を復元するヘルパー。
 # 引数はインストール先 skill ディレクトリ (存在しない場合は何もしない)。
 _ymt_skill_restore_exec() {
     local dir="$1"
     [[ -d "$dir" ]] || return 0
-    local f first
-    find "$dir" -type f -print0 2>/dev/null | while IFS= read -r -d '' f; do
-        IFS= read -r first < "$f" 2>/dev/null || continue
-        [[ "$first" == '#!'* ]] && chmod u+x "$f"
-    done
+    find "$dir" -type f -name '*.sh' -exec chmod u+x {} + 2>/dev/null
     return 0
 }
 


### PR DESCRIPTION
## Summary

`gh skill install` 後の実行権限復元処理 (`_ymt_skill_restore_exec`) を shebang 判定から `*.sh` ファイル判定へ変更しました。あわせて `skill add` / `skill update` で発生していた `suspended (tty output)` 表示を解消します。

## Key Changes

- `_ymt_skill_restore_exec` から `find ... -print0 | while read` + 各ファイルの shebang (`#!`) 判定を撤廃
- 代わりに `find "$dir" -type f -name '*.sh' -exec chmod u+x {} +` で `*.sh` ファイルにまとめて `u+x` を付与

## Impact

- #171 で混入した `suspended (tty output)`（バックグラウンドジョブ内のパイプ + `read` が SIGTTOU を誘発）が解消される
- 実行権限の付与対象が「shebang を持つ任意ファイル」→「`*.sh` ファイル」に変わる。shebang を持つが拡張子が `.sh` でないスクリプトには `+x` が付かなくなる点に注意

## Verification

- `zsh -n .zsh/functions/skill` → syntax OK
- interactive zsh で 5 並列バックグラウンドジョブを再現テスト → suspended 表示なし、全 `*.sh` に exec bit 付与を確認
