### PR TITLE
feat(nvim): add :ImageToggle/Disable/Enable commands for image.nvim

### DIFF
--- a/.config/nvim/lua/plugins/editor.lua
+++ b/.config/nvim/lua/plugins/editor.lua
@@ -72,6 +72,27 @@ return {
         window_overlap_clear_enabled = false,
         window_overlap_clear_ft_ignore = { 'cmp_menu', 'cmp_docs', '' },
       })
+
+      local image = require('image')
+      vim.api.nvim_create_user_command('ImageDisable', function()
+        image.disable()
+        vim.g.image_disabled = true
+      end, { desc = 'Disable image.nvim rendering' })
+      vim.api.nvim_create_user_command('ImageEnable', function()
+        image.enable()
+        vim.g.image_disabled = false
+      end, { desc = 'Enable image.nvim rendering' })
+      vim.api.nvim_create_user_command('ImageToggle', function()
+        if vim.g.image_disabled then
+          image.enable()
+          vim.g.image_disabled = false
+          vim.notify('image.nvim: enabled')
+        else
+          image.disable()
+          vim.g.image_disabled = true
+          vim.notify('image.nvim: disabled')
+        end
+      end, { desc = 'Toggle image.nvim rendering' })
     end,
   },
 


### PR DESCRIPTION
## Summary
- markdown 編集中に画像プレビューを一時的に止めたいケース向けに, `image.nvim` の enable/disable をラップした user command を追加
- `:ImageDisable` / `:ImageEnable` / `:ImageToggle` の 3 つを定義（`:ImageToggle` は `vim.notify` で状態を通知）
- 状態は `vim.g.image_disabled` に保持（将来 statusline 等から参照可能）

## Test plan
- [ ] nvim を再起動して markdown ファイルを開く
- [ ] `:ImageToggle` で画像が消える / 戻ることを確認
- [ ] `:ImageDisable` → `:ImageEnable` の往復が機能することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)