### PR TITLE
docs: 現行設定と乖離するドキュメント記述を修正

### DIFF
--- a/docs/nvim.md
+++ b/docs/nvim.md
@@ -103,18 +103,6 @@ Insert モードで動作します。`<Tab>` は Copilot → スニペット →
 
 > **Note:** サジェストの受け入れは `Tab` (Smart Tab) で行います。
 
-### Copilot Chat
-
-| キー操作 | モード | 動作 | 設定元 |
-|---|---|---|---|
-| `<leader>cc` | Normal | Copilot Chat の表示/非表示 | `plugins/copilot.lua` |
-| `<leader>ce` | Normal, Visual | コードの説明 | `plugins/copilot.lua` |
-| `<leader>cr` | Normal, Visual | コードレビュー | `plugins/copilot.lua` |
-| `<leader>cf` | Normal, Visual | バグ修正 | `plugins/copilot.lua` |
-| `<leader>co` | Normal, Visual | コード最適化 | `plugins/copilot.lua` |
-| `<leader>cd` | Normal, Visual | ドキュメント生成 | `plugins/copilot.lua` |
-| `<leader>ct` | Normal, Visual | テスト生成 | `plugins/copilot.lua` |
-
 ## Treesitter (選択範囲)
 
 Operator-pending / Visual モードで動作します。

--- a/docs/tmux.md
+++ b/docs/tmux.md
@@ -39,8 +39,8 @@
 
 | キー操作 | 動作 | 設定元 |
 |---|---|---|
-| `Prefix` + `y` | コピーモード開始 (デフォルトの `[` も使用可能) | `.tmux.conf` |
-| `Prefix` + `p` | バッファの内容をペースト (デフォルトの `]` も使用可能) | `.tmux.conf` |
+| `Prefix` + `y` | コピーモード開始 | `.tmux.conf` |
+| `Prefix` + `p` | バッファの内容をペースト | `.tmux.conf` |
 | `v` | 選択開始 (Visual selection) | `.tmux.conf` |
 | `C-v` | 短形選択 (Rectangle toggle) | `.tmux.conf` |
 | `y` | 選択範囲をコピー (システムクリップボードへ `pbcopy`) | `.tmux.conf` |

--- a/docs/zsh.md
+++ b/docs/zsh.md
@@ -49,9 +49,9 @@ Zshは Vi モード (`bindkey -v`) で動作するように設定されていま
 | `lg` | `lazygit` | `.zshrc` |
 | `ni` | `nvim` | `.zshrc` |
 | `tinyvim` | 最小構成 (`.vimrc.minimal`) で Vim を起動 | `.zshrc` |
-| `tinyprompt` | 画面収録用にプロンプトを簡素化 (`$ ` のみ等) | `.zshrc` |
-| `normalprompt` | プロンプトを通常の状態に戻す | `.zshrc` |
 | `qr` | `qrencode -t UTF8` (QRコード生成) | `.zshrc` |
+| `prompt left off` | 画面収録用にプロンプトを簡素化 (`$ ` のみ等) | `.zsh/functions/prompt` |
+| `prompt left on` | プロンプトを通常の状態に戻す | `.zsh/functions/prompt` |
 
 ---
 


### PR DESCRIPTION
## Summary
- nvim.md: アンインストール済み CopilotChat セクション（7 キーバインド）を削除
- zsh.md: 存在しない `tinyprompt`/`normalprompt` エイリアスを `prompt left off/on` 関数に訂正
- tmux.md: `.tmux.conf` で unbind 済みのコピーモード代替キー `[`/`]` の注記を削除

## Test plan
- [ ] 各 doc の Markdown 構文が正しいことを確認
- [ ] 修正内容が実際の設定ファイル（`.config/nvim/lua/plugins/copilot.lua`, `.zsh/functions/prompt`, `.tmux.conf`）と整合することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)