### PR TITLE
feat: markdownlint のグローバル設定を追加

### DIFF
--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -1,0 +1,23 @@
+# markdownlint configuration
+# https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+
+# MD013 - Line length
+# 日本語は 1 文字あたりバイト幅が大きく、行長制限と相性が悪いため無効化
+MD013: false
+
+# MD024 - Multiple headings with the same content
+# CHANGELOG などで同名見出しが繰り返されるケースを許容
+MD024:
+  siblings_only: true
+
+# MD033 - Inline HTML
+# GitHub 向け details/summary や br タグを許容
+MD033: false
+
+# MD034 - Bare URL used
+# リンクテキスト不要な URL をそのまま貼るケースが多いため許容
+MD034: false
+
+# MD041 - First line in a file should be a top-level heading
+# frontmatter 付きファイルや README 以外のドキュメントで不要
+MD041: false

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -38,6 +38,7 @@ TARGETS=( \
          ".config/yazi" \
          ".config/lazygit" \
          ".hammerspoon" \
+         ".markdownlint.yml" \
        )
 
 for TARGET in ${TARGETS[@]}


### PR DESCRIPTION
## Summary
- `$HOME/.markdownlint.yml` としてリンクされるグローバル設定ファイルを追加
- 日本語環境やドキュメント運用で不要なルール (MD013, MD033, MD034, MD041) を無効化し、MD024 は siblings_only に緩和
- `bin/link.sh` のリンク対象に `.markdownlint.yml` を追加

## 無効化ルール

| ルール | 設定 | 理由 |
|--------|------|------|
| MD013 (行長制限) | 無効 | 日本語との相性が悪い |
| MD024 (同名見出し) | siblings_only | CHANGELOG 等で同名見出しの繰り返しを許容 |
| MD033 (インライン HTML) | 無効 | `<details>`/`<summary>` 等を許容 |
| MD034 (Bare URL) | 無効 | リンクテキスト不要な URL の直貼りを許容 |
| MD041 (先頭が h1) | 無効 | frontmatter 付きファイル等で不要 |

## Test plan
- [x] `make link` で `$HOME/.markdownlint.yml` にシンボリックリンクが作成されることを確認
- [x] Mason 経由の markdownlint が設定を読み込み、無効化ルールの警告が出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)