### PR TITLE
fix(nvim): Markdown 保存時の自動フォーマットを無効化

### DIFF
--- a/.config/nvim/lua/plugins/conform.lua
+++ b/.config/nvim/lua/plugins/conform.lua
@@ -33,6 +33,7 @@ return {
         jsonc = true,
         css = true,
         html = true,
+        markdown = true,
       }
       if dominated_by_project[vim.bo[bufnr].filetype] then
         return false


### PR DESCRIPTION
## Summary
- `---` (thematic break) と HTML コメント / 見出しが連続する Markdown を nvim で保存すると, prettier の整形仕様により間に空行が強制挿入される問題を修正。
- HTML/JS 系 (#184) と同じ方針で Markdown も `format_on_save` の対象から除外し, プロジェクト側の prettier 設定や markdownlint に整形を委ねる。
- 手動フォーマット (`<leader>cf`) は `formatters_by_ft` に markdown を残しているため引き続き利用可能。

## 再現
保存前:

\`\`\`md
---
<!-- markdownlint-disable-next-line MD025 -->
# 中小企業の営業調査を Skill 化した漸進型 DX の実装例
\`\`\`

修正前の保存後 (prettier が空行を挿入):

\`\`\`md
---

<!-- markdownlint-disable-next-line MD025 -->

# 中小企業の営業調査を Skill 化した漸進型 DX の実装例
\`\`\`

## Test plan
- [x] `prettierd` で当該 Markdown を整形すると空行が入ることを確認 (再現)
- [x] `nvim --headless sample.md -c 'w' -c 'qa!'` で保存しても空行が入らないことを確認
- [ ] 実利用環境で `:w` 時に Markdown が変更されないことを確認
- [ ] `<leader>cf` で手動フォーマットがこれまで通り動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)