### PR TITLE
feat: skill list サブコマンドを追加

### DIFF
--- a/.zsh/functions/_skill
+++ b/.zsh/functions/_skill
@@ -1,7 +1,7 @@
 #compdef skill
 
 # skill の補完定義
-# 第1引数でサブコマンド (add/update/remove) を補完し, その後サブコマンド固有の
+# 第1引数でサブコマンド (add/update/remove/list) を補完し, その後サブコマンド固有の
 # オプション/引数を補完する。skill 選択自体は fzf が担うため, 補完は
 # サブコマンド名・オプション・add の repository (owner/repo) のみ。
 
@@ -12,6 +12,7 @@ _skill() {
     'add:install skills from a GitHub repository'
     'update:update installed skills to their latest version'
     'remove:remove installed skills'
+    'list:list installed skills as columnar plain text'
   )
 
   _arguments -C \
@@ -43,6 +44,12 @@ _skill() {
             '(-h --help)'{-h,--help}'[print help]' \
             '(-g --global -u --user)'{-g,--global}'[remove from global (user) scope ($HOME)]' \
             '(-g --global -u --user)'{-u,--user}'[remove from global (user) scope ($HOME)]'
+          ;;
+        list)
+          _arguments \
+            '(-h --help)'{-h,--help}'[print help]' \
+            '(-g --global -u --user)'{-g,--global}'[list global (user) scope skills ($HOME)]' \
+            '(-g --global -u --user)'{-u,--user}'[list global (user) scope skills ($HOME)]'
           ;;
       esac
       ;;

--- a/.zsh/functions/skill
+++ b/.zsh/functions/skill
@@ -20,14 +20,16 @@ Usage:
   skill add [-g] <owner/repo>   skill をインストール (project scope, -g で user scope)
   skill update [-g]             インストール済み skill を fzf で選択して最新化
   skill remove [-g]             インストール済み skill を fzf で選択して削除
+  skill list [-g]               インストール済み skill を一覧表示
   skill -h                      print this help
 
 Subcommands:
   add      GitHub リポジトリの skill を .claude/skills と .agents/skills へ追加
   update   インストール済み skill を frontmatter から自動解決して最新へ更新
   remove   .claude/skills と .agents/skills から skill を削除
+  list     インストール済み skill を plain text で一覧表示 (パイプ・grep 向け)
 
-詳細は "skill add -h" / "skill update -h" / "skill remove -h" を参照してください。'
+詳細は "skill add -h" / "skill update -h" / "skill remove -h" / "skill list -h" を参照してください。'
 }
 
 # add サブコマンドのヘルプ
@@ -137,6 +139,35 @@ Dependencies:
   fzf
   git  (project scope 時のみ必須)
   bat  (任意: あれば SKILL.md プレビューを syntax highlight)'
+}
+
+# list サブコマンドのヘルプ
+_ymt_skill_list_usage() {
+  print -r -- 'skill list prints installed skills as columnar plain text
+(suitable for piping to grep / awk).
+
+.claude/skills と .agents/skills の union を取り, skill ごとに status / 元リポジトリ
+(github-repo) / pin バージョン (github-pinned) を表示します。frontmatter が取れない
+skill では repo / pin 列に "-" を出します。
+
+Usage:
+  skill list                  現在の git リポジトリ (project scope) の skill を一覧
+  skill list -g               $HOME (global/user scope) の skill を一覧
+  skill list -h               print help
+
+Options:
+  -h, --help                  print help
+  -g, --global, -u, --user    global (user) scope の skill を一覧 ($HOME 基準)
+
+Output columns:
+  NAME     skill 名 (ディレクトリ名)
+  REPO     github-repo (frontmatter, 無ければ "-")
+  PIN      github-pinned (frontmatter, 無ければ "-")
+  STATUS   [both] / [claude] / [agents]
+
+Dependencies:
+  git  (project scope 時のみ必須)
+  awk  (frontmatter パース; 標準コマンド)'
 }
 
 # gh skill install は GitHub API 経由でファイルを取得するため exec bit を保持しない。
@@ -882,6 +913,137 @@ _ymt_skill_remove() {
   echo "Done: ${#selected[@]} skill(s) removed."
 }
 
+# list サブコマンド本体
+# インストール済み skill を STATUS / NAME / REPO / PIN の 4 列で plain text 出力する。
+# fzf は使わない (パイプ・grep 用途を優先)。
+#
+# 注意: base_dir 決定 / skill_union 収集 / frontmatter パースは _ymt_skill_remove /
+# _ymt_skill_update と同一だが, ヘルパー関数化は別 PR に切り出す方針 (L400-402 参照)
+# に従いここでは流用 (コピー) で実装する。
+_ymt_skill_list() {
+  # ヘルプ / 引数チェック (位置引数は取らない)
+  local global_mode=0
+  while (( $# > 0 )); do
+    case "$1" in
+      -h|--help|help)
+        _ymt_skill_list_usage
+        return 0
+        ;;
+      -g|--global|-u|--user)
+        global_mode=1
+        shift
+        ;;
+      -*)
+        echo "Error: unknown option: $1" >&2
+        _ymt_skill_list_usage >&2
+        return 1
+        ;;
+      *)
+        echo "Error: unexpected argument: $1" >&2
+        _ymt_skill_list_usage >&2
+        return 1
+        ;;
+    esac
+  done
+
+  # Check dependencies (git は project scope 時のみ必須。awk は標準前提)
+  if (( !global_mode )); then
+    if ! command -v git >/dev/null 2>&1; then
+      echo "Error: git command not found. Please install git." >&2
+      return 1
+    fi
+  fi
+
+  # インストール先ベースディレクトリを決定する
+  local base_dir
+  if (( global_mode )); then
+    base_dir="$HOME"
+  else
+    local repo_root
+    repo_root=$(git rev-parse --show-toplevel 2>/dev/null)
+    if [[ -z "$repo_root" ]]; then
+      echo "Error: Not a git repository." >&2
+      echo "  global scope の skill を一覧するには -g オプションを使用してください。" >&2
+      return 1
+    fi
+    base_dir="$repo_root"
+  fi
+
+  # 両ディレクトリからインストール済み skill 名を収集し union を作る
+  local -A skill_union
+  local d
+  for d in "$base_dir/.claude/skills"/*(N/); do
+    skill_union[${d:t}]=1
+  done
+  for d in "$base_dir/.agents/skills"/*(N/); do
+    skill_union[${d:t}]=1
+  done
+
+  if (( ${#skill_union} == 0 )); then
+    echo "No skills installed in $base_dir."
+    return 0
+  fi
+
+  # skill ごとに status / repo / pin を決定して TAB 区切り行を作る。
+  # column -t -s $'\t' に流して列揃えするため, 区切りは必ず 1 個の TAB とする。
+  # 注意: 'status' は zsh の read-only 特殊変数 ($? のエイリアス) なので使えない。
+  #   status 列の値は st で保持する。
+  local skill_name skill_md has_claude has_agents st repo_url repo pinned
+  local fm_key fm_val
+  local _tab=$'\t'
+  local -a rows
+  rows+=("NAME${_tab}REPO${_tab}PIN${_tab}STATUS")
+
+  # (o) でキー (skill 名) をソートして出力順を安定させる
+  for skill_name in "${(@ko)skill_union}"; do
+    # status
+    has_claude=0
+    has_agents=0
+    [[ -e "$base_dir/.claude/skills/$skill_name" ]] && has_claude=1
+    [[ -e "$base_dir/.agents/skills/$skill_name" ]] && has_agents=1
+    if (( has_claude && has_agents )); then
+      st="[both]"
+    elif (( has_claude )); then
+      st="[claude]"
+    else
+      st="[agents]"
+    fi
+
+    # SKILL.md は .claude/skills 優先, 無ければ .agents/skills を見る
+    skill_md="$base_dir/.claude/skills/$skill_name/SKILL.md"
+    [[ -f "$skill_md" ]] || skill_md="$base_dir/.agents/skills/$skill_name/SKILL.md"
+
+    repo_url=""
+    pinned=""
+    if [[ -f "$skill_md" ]]; then
+      # frontmatter (先頭 --- ... ---) の metadata から github-repo / github-pinned を抽出。
+      # _ymt_skill_update と同じ awk スニペット (d==1 で frontmatter 内に限定)。
+      while IFS=$'\t' read -r fm_key fm_val; do
+        case "$fm_key" in
+          github-repo)   repo_url="$fm_val" ;;
+          github-pinned) pinned="$fm_val" ;;
+        esac
+      done < <(awk '
+        /^---[[:space:]]*$/ { d++; next }
+        d==1 && /^[[:space:]]+github-(repo|pinned):[[:space:]]/ {
+          key=$1; sub(/:$/, "", key); $1=""; sub(/^[[:space:]]+/, "")
+          print key "\t" $0
+        }
+      ' "$skill_md")
+    fi
+
+    # repo は https://github.com/ プレフィックスと .git サフィックスを剥がす
+    repo="${repo_url#https://github.com/}"
+    repo="${repo%.git}"
+    [[ -z "$repo" ]] && repo="-"
+    [[ -z "$pinned" ]] && pinned="-"
+
+    rows+=("${skill_name}${_tab}${repo}${_tab}${pinned}${_tab}${st}")
+  done
+
+  printf '%s\n' "${rows[@]}" | column -t -s $'\t'
+}
+
 # サブコマンドディスパッチ。各サブ関数の終了ステータスを return $? で伝播する。
 local subcmd="${1:-}"
 case "$subcmd" in
@@ -902,6 +1064,11 @@ case "$subcmd" in
   remove)
     shift
     _ymt_skill_remove "$@"
+    return $?
+    ;;
+  list)
+    shift
+    _ymt_skill_list "$@"
     return $?
     ;;
   *)

--- a/.zsh/functions/skill
+++ b/.zsh/functions/skill
@@ -914,7 +914,7 @@ _ymt_skill_remove() {
 }
 
 # list サブコマンド本体
-# インストール済み skill を STATUS / NAME / REPO / PIN の 4 列で plain text 出力する。
+# インストール済み skill を NAME / REPO / PIN / STATUS の 4 列で plain text 出力する。
 # fzf は使わない (パイプ・grep 用途を優先)。
 #
 # 注意: base_dir 決定 / skill_union 収集 / frontmatter パースは _ymt_skill_remove /


### PR DESCRIPTION
## Summary

`skill` コマンドに `list` サブコマンドを追加し, インストール済み skill を plain text で一覧できるようにした。従来は `update` / `remove` の fzf 経由でしか確認できず, パイプ・grep 用途に不向きだった。

## Key Changes

- `_ymt_skill_list_usage` / `_ymt_skill_list` を新設し, `skill list [-g]` を実装
- `.claude/skills` と `.agents/skills` の union からインストール済み skill 名を集め, columnar な 4 列 (`NAME` / `REPO` / `PIN` / `STATUS`) で出力
- `REPO` / `PIN` は `SKILL.md` frontmatter の `github-repo` / `github-pinned` から抽出 (取れなければ `-`)。抽出ロジックは `_ymt_skill_update` と同じ awk パターンを流用
- `STATUS` は `[both]` / `[claude]` / `[agents]` (`remove` で使う `-only` サフィックスは付けず短縮)
- 全体 usage (`_ymt_skill_usage`) と dispatch (`case "$subcmd"`) に `list` を追加

## Impact

- 新しいサブコマンドのみで既存 (`add` / `update` / `remove`) には影響しない
- fzf 非依存の read-only コマンドなので副作用なし
- `list` の status marker は `remove` のものと若干異なる (`[claude-only]` → `[claude]` / `[agents-only]` → `[agents]`) が, `remove` 側は本 PR では変更していない
