### PR TITLE
feat: company-tasks の Target Date 色を Chrome extension に合わせる

### DIFF
--- a/.zsh/functions/company-tasks
+++ b/.zsh/functions/company-tasks
@@ -35,10 +35,9 @@ Options:
   --refresh-me                           me キャッシュを強制更新
 
 色凡例 (TTY 出力時):
-  赤      過去期限 (overdue)
-  橙      当日 (今日が期限)
-  黄      1〜3 日以内
-  cyan    4〜7 日以内
+  赤 (bold)      過去期限 (overdue)
+  褐色 (bold)    当日 (今日が期限)
+  青             1〜7 日以内
 
 親子情報 (行末注記):
   ↑repo#N   親 issue への参照 (親を持つ場合)
@@ -422,10 +421,9 @@ _ymt_ct_iteration_bucket_title() {
 # $1: title, $2: json, $3: me
 _ymt_ct_render() {
   local title="$1" json="$2" me="$3"
-  local count today_date d3_date d7_date
+  local count today_date d7_date
   count=$(printf '%s' "$json" | jq 'length')
   today_date=$(date +%Y-%m-%d)
-  d3_date=$(date -v+3d +%Y-%m-%d)
   d7_date=$(date -v+7d +%Y-%m-%d)
 
   echo "## ${title} — ${count} 件"
@@ -435,19 +433,21 @@ _ymt_ct_render() {
     return 0
   fi
 
-  local C_RED C_ORANGE C_YELLOW C_CYAN C_GRAY C_RESET
+  # Chrome extension (github-project-support) の COLOR_PALETTE と対応:
+  #   overdue   #cf222e ≒ ANSI 256 #160 (#d70000) + bold
+  #   today     #9a6700 ≒ ANSI 256 #94  (#875f00) + bold
+  #   1〜7 日   #1f6feb ≒ ANSI 256 #33  (#0087ff)
+  local C_OVERDUE C_TODAY C_WEEK C_GRAY C_RESET
   if [[ -t 1 ]]; then
-    C_RED=$'\033[31m'
-    C_ORANGE=$'\033[38;5;208m'
-    C_YELLOW=$'\033[33m'
-    C_CYAN=$'\033[36m'
+    C_OVERDUE=$'\033[1;38;5;160m'
+    C_TODAY=$'\033[1;38;5;94m'
+    C_WEEK=$'\033[38;5;33m'
     C_GRAY=$'\033[90m'
     C_RESET=$'\033[0m'
   else
-    C_RED=""
-    C_ORANGE=""
-    C_YELLOW=""
-    C_CYAN=""
+    C_OVERDUE=""
+    C_TODAY=""
+    C_WEEK=""
     C_GRAY=""
     C_RESET=""
   fi
@@ -469,8 +469,8 @@ _ymt_ct_render() {
           ((.sub_count // 0) | tostring)
         ] | @tsv' \
     | awk -F'\t' \
-          -v today="$today_date" -v d3="$d3_date" -v d7="$d7_date" \
-          -v cred="$C_RED" -v corange="$C_ORANGE" -v cyel="$C_YELLOW" -v ccyan="$C_CYAN" \
+          -v today="$today_date" -v d7="$d7_date" \
+          -v covd="$C_OVERDUE" -v ctoday="$C_TODAY" -v cweek="$C_WEEK" \
           -v cgray="$C_GRAY" -v creset="$C_RESET" \
           -v up_arrow="↑" -v down_arrow="↓" '
         function pad(s, n,    deficit) {
@@ -486,10 +486,9 @@ _ymt_ct_render() {
 
           color = ""
           if (raw_target != "未設定") {
-            if      (raw_target <  today) color = cred
-            else if (raw_target == today) color = corange
-            else if (raw_target <= d3)    color = cyel
-            else if (raw_target <= d7)    color = ccyan
+            if      (raw_target <  today) color = covd
+            else if (raw_target == today) color = ctoday
+            else if (raw_target <= d7)    color = cweek
           }
 
           if (iter == "") {


### PR DESCRIPTION
## Summary

`company-tasks` (zsh function) と Chrome extension [`github-project-support`](../../fillin/chrome-extensions/github-project-support) は同じ GitHub Projects V2 の Target Date を見せているが、色分けが独立して設計されていたため CLI とブラウザで期限感覚がズレていた。Chrome extension の `COLOR_PALETTE` を基準に、CLI 側のバケット構成と色味を統一する。

## Key Changes

- `.zsh/functions/company-tasks`
  - Target Date の色分けバケットを 4 段階 (overdue / today / 1〜3d / 4〜7d) から 3 段階 (overdue / today / 1〜7d) に縮約
  - ANSI 変数名を役割ベース (`C_OVERDUE` / `C_TODAY` / `C_WEEK`) に変更し、Chrome extension の `Bucket` 型 (`overdue` / `due-today` / `due-week`) と対応させた
  - 色を Chrome extension の hex 値に近い ANSI 256 色 + bold に差し替え
    - overdue: `\033[1;38;5;160m` (`#d70000` ≒ `#cf222e`) + bold
    - today:   `\033[1;38;5;94m`  (`#875f00` ≒ `#9a6700`) + bold
    - 1〜7d:   `\033[38;5;33m`    (`#0087ff` ≒ `#1f6feb`)
  - ヘルプの色凡例を新 3 段階に更新

## Impact

- CLI とブラウザ拡張で同じ Issue の Target Date を見たとき、期限カテゴリ (色) が一致するようになる
- 「未設定」/「8 日以降」= 無色、他列 (Iteration / Assignee) の `-` を灰色にする副次ロジックは維持
- 非 TTY 時 (`company-tasks | cat` 等) は従来通り ANSI エスケープを出力しない
- 色空間の完全一致は端末カラープロファイルに依存するため、「同じ緊急度カテゴリに見える」ことを合格基準とする

## Test Plan

- [x] `zsh -n .zsh/functions/company-tasks` で文法確認
- [x] awk 部分の dry-run で各バケット (overdue / today / 3d / 7d / 8d / 未設定) が期待の ANSI コードで出力されることを確認
- [x] 色なし行の Iteration `-` / Assignee `-` が引き続き灰色 (`\033[90m`) で出ることを確認
- [ ] 実 GitHub Projects データで `company-tasks` を実行し、Chrome extension の Table view と Target Date の色カテゴリが一致することを目視確認
