### PR TITLE
feat: herdr と hunk を導入

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,31 @@
+# herdr configuration
+# https://herdr.dev/docs/configuration/
+# Keybindings are aligned with .tmux.conf (prefix: C-e)
+
+[keys]
+# tmux: set-option -g prefix C-e
+prefix = "ctrl+e"
+
+# tmux: bind \ split-window -h / bind - split-window -v
+split_vertical = "prefix+\\"
+split_horizontal = "prefix+minus"
+
+# tmux: bind z kill-pane (keep herdr default prefix+x too)
+close_pane = ["prefix+z", "prefix+x"]
+# zoom moves aside because prefix+z is taken by close_pane
+zoom = "prefix+shift+z"
+
+# tmux: bind C-n next-window (keep herdr default prefix+n too)
+next_tab = ["prefix+n", "prefix+ctrl+n"]
+
+# goto moves aside because prefix+g opens lazygit (prefix+shift+g is new_worktree)
+goto = "prefix+f"
+
+# tmux: bind g display-popup lazygit
+[[keys.command]]
+key = "prefix+g"
+type = "popup"
+command = "lazygit"
+description = "run lazygit"
+width = "98%"
+height = "98%"

--- a/.config/hunk/config.toml
+++ b/.config/hunk/config.toml
@@ -1,0 +1,9 @@
+# hunk configuration
+# https://github.com/modem-dev/hunk
+
+theme = "auto"     # follow terminal light/dark
+mode = "auto"      # split / stack auto-selection
+vcs = "git"
+watch = false
+line_numbers = true
+agent_notes = true # show inline annotations from AI agents (Claude Code / Codex)

--- a/bin/homebrew/cli.sh
+++ b/bin/homebrew/cli.sh
@@ -27,7 +27,9 @@ brew install \
           grep \
           font-symbols-only-nerd-font \
           fzf \
+          herdr \
           htop \
+          hunk \
           imagemagick \
           pngpaste \
           jq \

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -37,6 +37,8 @@ TARGETS=( \
          ".config/nvim" \
          ".config/yazi" \
          ".config/lazygit" \
+         ".config/herdr/config.toml" \
+         ".config/hunk/config.toml" \
          ".hammerspoon" \
          ".markdownlint.yml" \
        )
@@ -54,6 +56,9 @@ do
     if [ -L $DEST ]; then
       echo "exist: $DEST"
     else
+      # herdr や hunk はランタイム状態を config ディレクトリに書き込むため
+      # ディレクトリごとではなく設定ファイル単体をリンクする (親ディレクトリを事前作成)
+      mkdir -p "$(dirname "$DEST")"
       echo "link: $DEST"
       ln -s $SOURCE $DEST
     fi


### PR DESCRIPTION
## Summary

Claude Code / Codex の活用のために流行している 2 ツール (herdr / hunk) を dotfiles に導入します。

## Key Changes

- `bin/homebrew/cli.sh`: `herdr` / `hunk` を formula リストに追加 (どちらも homebrew-core)
  - herdr: AI エージェントの状態 (blocked/working/done) を可視化するターミナルマルチプレクサ
  - hunk: エージェント製 changeset 向けのレビュー特化ターミナル diff ビューア
- `.config/herdr/config.toml` (新規): keybinding を `.tmux.conf` にフル準拠
  - prefix `ctrl+e`, split `\` / `-`, kill-pane `z` (zoom は `shift+z` へ退避), next-tab `C-n`, `g` で lazygit popup (goto は `f` へ退避)
- `.config/hunk/config.toml` (新規): ベース設定 + `agent_notes = true` (Claude Code / Codex のインラインアノテーション表示)
- `bin/link.sh`:
  - TARGETS に上記 2 ファイルを追加
  - herdr / hunk はランタイム状態 (log / socket / state.json) を config ディレクトリに書き込むため、ディレクトリごとではなく `config.toml` 単体をリンクする方式にし、リンク前に親ディレクトリを `mkdir -p` で作成するよう変更

## Impact

- `make cli` / `make link` (および `make setup`) に自動で組み込まれます
- 既存リンク対象への影響なし (`mkdir -p` は既存の `~/.config` 配下では no-op)
- herdr を tmux 内で起動すると prefix `C-e` は tmux 側に取られるため、単体起動を想定

## 検証

- `bash -n bin/link.sh` / `sh -n bin/homebrew/cli.sh` で文法チェック、shellcheck は追加行の指摘を解消 (既存行の指摘はスコープ外)
- `brew install herdr hunk` 実施 (herdr 0.7.4 / hunk 0.17.1)
- `make link` で symlink 作成を確認
- `herdr config check` → `config: ok` (不正キーを検出することも負のテストで確認済み)
- `hunk show` を起動し設定読み込みエラーなし、`state.json` が `~/.config/hunk/` (実ディレクトリ) 側に書かれリポジトリを汚さないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
