### PR TITLE
feat: tmux にエージェント状態インジケータを追加

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -73,8 +73,8 @@ set -g window-status-style fg=colour245,bg=black
 setw -g window-status-current-style fg=green,bg=black
 
 # AI agent status indicators (per-pane, written by ~/.tmux/agent-status.sh)
-setw -g window-status-format ' #I:#W#{?window_flags,#{window_flags},}#{P:#{@agent_status}} '
-setw -g window-status-current-format ' #I:#W#{?window_flags,#{window_flags},}#{P:#{@agent_status}} '
+setw -g window-status-format ' #I:#W#{?window_flags,#{window_flags},}#{?#{P:#{@agent_status}}, #{P:#{@agent_status}},} '
+setw -g window-status-current-format ' #I:#W#{?window_flags,#{window_flags},}#{?#{P:#{@agent_status}}, #{P:#{@agent_status}},} '
 
 # resize pane
 bind -r H resize-pane -L 5

--- a/.tmux.conf
+++ b/.tmux.conf
@@ -72,6 +72,10 @@ set -g window-active-style 'fg=colour250,bg=default'
 set -g window-status-style fg=colour245,bg=black
 setw -g window-status-current-style fg=green,bg=black
 
+# AI agent status indicators (per-pane, written by ~/.tmux/agent-status.sh)
+setw -g window-status-format ' #I:#W#{?window_flags,#{window_flags},}#{P:#{@agent_status}} '
+setw -g window-status-current-format ' #I:#W#{?window_flags,#{window_flags},}#{P:#{@agent_status}} '
+
 # resize pane
 bind -r H resize-pane -L 5
 bind -r J resize-pane -D 5

--- a/.tmux/agent-status.sh
+++ b/.tmux/agent-status.sh
@@ -1,0 +1,37 @@
+#!/bin/sh
+
+# Set per-pane AI agent status for the tmux status line.
+# Called from Claude Code / Codex hooks with the state as the first argument.
+# The state is stored in the pane option @agent_status and rendered by the
+# pane loop #{P:#{@agent_status}} in window-status-format.
+#
+# Usage: agent-status.sh <working|blocked|idle|clear>
+
+set -e
+
+# no-op outside tmux
+[ -n "${TMUX:-}" ] || exit 0
+[ -n "${TMUX_PANE:-}" ] || exit 0
+command -v tmux >/dev/null 2>&1 || exit 0
+
+case "${1:-}" in
+    working)
+        color="colour33"
+        ;;
+    blocked)
+        color="colour160"
+        ;;
+    idle)
+        color="colour34"
+        ;;
+    clear)
+        tmux set-option -p -t "$TMUX_PANE" -u @agent_status 2>/dev/null || true
+        exit 0
+        ;;
+    *)
+        echo "Usage: $0 <working|blocked|idle|clear>" >&2
+        exit 1
+        ;;
+esac
+
+tmux set-option -p -t "$TMUX_PANE" @agent_status " #[fg=${color}]●#[default]" 2>/dev/null || true

--- a/.tmux/agent-status.sh
+++ b/.tmux/agent-status.sh
@@ -34,4 +34,4 @@ case "${1:-}" in
         ;;
 esac
 
-tmux set-option -p -t "$TMUX_PANE" @agent_status " #[fg=${color}]●#[default]" 2>/dev/null || true
+tmux set-option -p -t "$TMUX_PANE" @agent_status "#[fg=${color}]●#[default]" 2>/dev/null || true

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,14 @@ asdf: asdf_update asdf_langs asdf_infra ## Install All asdf
 mac: ## Apply Macbook Setting
 	sh ./bin/mac.sh
 
+.PHONY: agent_hooks
+agent_hooks: ## Install AI agent status hooks (Claude Code / Codex)
+	sh ./bin/agent_hooks.sh
+
+.PHONY: agent_hooks_uninstall
+agent_hooks_uninstall: ## Uninstall AI agent status hooks
+	sh ./bin/agent_hooks.sh uninstall
+
 .PHONY: setup_develop
 setup_develop: homebrew cli app link asdf_ruby asdf_python asdf_cloud mac ## *setup develop machine
 

--- a/bin/agent_hooks.sh
+++ b/bin/agent_hooks.sh
@@ -25,6 +25,13 @@ if ! command -v python3 >/dev/null 2>&1; then
     exit 1
 fi
 
+# agent-status.sh must be linked before hooks are registered, otherwise every
+# hook invocation fails silently. Warn early instead of registering broken hooks.
+if [ "$MODE" = "install" ] && [ ! -e "$HOME/.tmux/agent-status.sh" ]; then
+    echo "error: $HOME/.tmux/agent-status.sh not found. Run 'make link' first." >&2
+    exit 1
+fi
+
 AGENT_HOOKS_MODE="$MODE" \
 AGENT_HOOKS_SCRIPT="$HOME/.tmux/agent-status.sh" \
 AGENT_HOOKS_CLAUDE="$HOME/.claude/settings.json" \
@@ -106,3 +113,11 @@ def update(path, events):
 update(os.environ["AGENT_HOOKS_CLAUDE"], CLAUDE_EVENTS)
 update(os.environ["AGENT_HOOKS_CODEX"], CODEX_EVENTS)
 PY
+
+if [ "$MODE" = "install" ]; then
+    cat >&2 <<'MSG'
+
+Note: Codex will not run the new hooks until you trust them.
+      Run 'codex' and execute '/hooks' to review and trust the entries.
+MSG
+fi

--- a/bin/agent_hooks.sh
+++ b/bin/agent_hooks.sh
@@ -20,99 +20,92 @@ case "$MODE" in
         ;;
 esac
 
-if ! command -v python3 >/dev/null 2>&1; then
-    echo "python3 is required" >&2
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required (brew install jq)" >&2
     exit 1
 fi
 
-# agent-status.sh must be linked before hooks are registered, otherwise every
-# hook invocation fails silently. Warn early instead of registering broken hooks.
-if [ "$MODE" = "install" ] && [ ! -e "$HOME/.tmux/agent-status.sh" ]; then
-    echo "error: $HOME/.tmux/agent-status.sh not found. Run 'make link' first." >&2
+SCRIPT="$HOME/.tmux/agent-status.sh"
+
+if [ "$MODE" = "install" ] && [ ! -e "$SCRIPT" ]; then
+    echo "error: $SCRIPT not found. Run 'make link' first." >&2
     exit 1
 fi
 
-AGENT_HOOKS_MODE="$MODE" \
-AGENT_HOOKS_SCRIPT="$HOME/.tmux/agent-status.sh" \
-AGENT_HOOKS_CLAUDE="$HOME/.claude/settings.json" \
-AGENT_HOOKS_CODEX="$HOME/.codex/hooks.json" \
-python3 <<'PY'
-import json
-import os
-
-mode = os.environ["AGENT_HOOKS_MODE"]
-script = os.environ["AGENT_HOOKS_SCRIPT"]
-
-# state transitions per hook event
-CLAUDE_EVENTS = {
+# event -> state mapping. Codex has no SessionEnd and uses PermissionRequest
+# where Claude uses Notification.
+CLAUDE_EVENTS='{
     "SessionStart": "idle",
     "Stop": "idle",
     "UserPromptSubmit": "working",
     "PostToolUse": "working",
     "Notification": "blocked",
-    "SessionEnd": "clear",
-}
-# Codex has no SessionEnd; PermissionRequest instead of Notification
-CODEX_EVENTS = {
+    "SessionEnd": "clear"
+}'
+CODEX_EVENTS='{
     "SessionStart": "idle",
     "Stop": "idle",
     "UserPromptSubmit": "working",
     "PostToolUse": "working",
-    "PermissionRequest": "blocked",
+    "PermissionRequest": "blocked"
+}'
+
+# Build {event: full_command} from {event: state}. The script path is wrapped
+# in single quotes so the command remains a valid shell command in the hook.
+build_commands() {
+    echo "$1" | jq --arg script "$SCRIPT" '
+        ([39] | implode) as $q
+        | to_entries
+        | map({key: .key, value: ("sh " + $q + $script + $q + " " + .value)})
+        | from_entries
+    '
 }
 
+update() {
+    path="$1"
+    commands="$2"
+    mkdir -p "$(dirname "$path")"
+    [ -f "$path" ] || echo '{}' > "$path"
 
-def load(path):
-    if os.path.exists(path):
-        with open(path) as f:
-            return json.load(f)
-    return {}
+    tmp=$(mktemp)
+    if [ "$MODE" = "install" ]; then
+        jq --argjson cmds "$commands" '
+            .hooks //= {}
+            | .hooks |= (
+                to_entries
+                | map(.value |= (
+                    map(.hooks |= map(select(.command | contains("agent-status.sh") | not)))
+                    | map(select(.hooks | length > 0))
+                ))
+                | map(select(.value | length > 0))
+                | from_entries
+            )
+            | reduce ($cmds | to_entries[]) as $e (.;
+                .hooks[$e.key] += [{
+                    hooks: [{type: "command", command: $e.value, timeout: 5}]
+                }]
+            )
+        ' "$path" > "$tmp"
+    else
+        jq '
+            .hooks //= {}
+            | .hooks |= (
+                to_entries
+                | map(.value |= (
+                    map(.hooks |= map(select(.command | contains("agent-status.sh") | not)))
+                    | map(select(.hooks | length > 0))
+                ))
+                | map(select(.value | length > 0))
+                | from_entries
+            )
+        ' "$path" > "$tmp"
+    fi
+    mv "$tmp" "$path"
+    echo "$path: $MODE done"
+}
 
-
-def strip_agent_entries(hooks):
-    for event in list(hooks.keys()):
-        groups = []
-        for group in hooks[event]:
-            commands = [
-                h for h in group.get("hooks", [])
-                if "agent-status.sh" not in h.get("command", "")
-            ]
-            if commands:
-                group["hooks"] = commands
-                groups.append(group)
-        if groups:
-            hooks[event] = groups
-        else:
-            del hooks[event]
-
-
-def add_entries(hooks, events):
-    for event, state in events.items():
-        hooks.setdefault(event, []).append({
-            "hooks": [{
-                "type": "command",
-                "command": "sh '%s' %s" % (script, state),
-                "timeout": 5,
-            }],
-        })
-
-
-def update(path, events):
-    data = load(path)
-    hooks = data.setdefault("hooks", {})
-    strip_agent_entries(hooks)
-    if mode == "install":
-        add_entries(hooks, events)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w") as f:
-        json.dump(data, f, indent=2, ensure_ascii=False)
-        f.write("\n")
-    print("%s: %s done" % (path, mode))
-
-
-update(os.environ["AGENT_HOOKS_CLAUDE"], CLAUDE_EVENTS)
-update(os.environ["AGENT_HOOKS_CODEX"], CODEX_EVENTS)
-PY
+update "$HOME/.claude/settings.json" "$(build_commands "$CLAUDE_EVENTS")"
+update "$HOME/.codex/hooks.json" "$(build_commands "$CODEX_EVENTS")"
 
 if [ "$MODE" = "install" ]; then
     cat >&2 <<'MSG'

--- a/bin/agent_hooks.sh
+++ b/bin/agent_hooks.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+
+# Install / uninstall AI agent status hooks for Claude Code and Codex.
+# Registers ~/.tmux/agent-status.sh as a hook command so that each CLI
+# reports its state (working / blocked / idle) to the tmux status line.
+# Existing hook entries that do not reference agent-status.sh are preserved.
+#
+# Usage: agent_hooks.sh [uninstall]
+
+set -e
+
+MODE="${1:-install}"
+
+case "$MODE" in
+    install|uninstall)
+        ;;
+    *)
+        echo "Usage: $0 [uninstall]" >&2
+        exit 1
+        ;;
+esac
+
+if ! command -v python3 >/dev/null 2>&1; then
+    echo "python3 is required" >&2
+    exit 1
+fi
+
+AGENT_HOOKS_MODE="$MODE" \
+AGENT_HOOKS_SCRIPT="$HOME/.tmux/agent-status.sh" \
+AGENT_HOOKS_CLAUDE="$HOME/.claude/settings.json" \
+AGENT_HOOKS_CODEX="$HOME/.codex/hooks.json" \
+python3 <<'PY'
+import json
+import os
+
+mode = os.environ["AGENT_HOOKS_MODE"]
+script = os.environ["AGENT_HOOKS_SCRIPT"]
+
+# state transitions per hook event
+CLAUDE_EVENTS = {
+    "SessionStart": "idle",
+    "Stop": "idle",
+    "UserPromptSubmit": "working",
+    "PostToolUse": "working",
+    "Notification": "blocked",
+    "SessionEnd": "clear",
+}
+# Codex has no SessionEnd; PermissionRequest instead of Notification
+CODEX_EVENTS = {
+    "SessionStart": "idle",
+    "Stop": "idle",
+    "UserPromptSubmit": "working",
+    "PostToolUse": "working",
+    "PermissionRequest": "blocked",
+}
+
+
+def load(path):
+    if os.path.exists(path):
+        with open(path) as f:
+            return json.load(f)
+    return {}
+
+
+def strip_agent_entries(hooks):
+    for event in list(hooks.keys()):
+        groups = []
+        for group in hooks[event]:
+            commands = [
+                h for h in group.get("hooks", [])
+                if "agent-status.sh" not in h.get("command", "")
+            ]
+            if commands:
+                group["hooks"] = commands
+                groups.append(group)
+        if groups:
+            hooks[event] = groups
+        else:
+            del hooks[event]
+
+
+def add_entries(hooks, events):
+    for event, state in events.items():
+        hooks.setdefault(event, []).append({
+            "hooks": [{
+                "type": "command",
+                "command": "sh '%s' %s" % (script, state),
+                "timeout": 5,
+            }],
+        })
+
+
+def update(path, events):
+    data = load(path)
+    hooks = data.setdefault("hooks", {})
+    strip_agent_entries(hooks)
+    if mode == "install":
+        add_entries(hooks, events)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    print("%s: %s done" % (path, mode))
+
+
+update(os.environ["AGENT_HOOKS_CLAUDE"], CLAUDE_EVENTS)
+update(os.environ["AGENT_HOOKS_CODEX"], CODEX_EVENTS)
+PY


### PR DESCRIPTION
## Summary

tmux 上で AI エージェント (Claude Code / Codex) の状態を可視化します。各 CLI の hook が pane 単位の状態を tmux の pane option に書き込み、status line のタブに pane ごとの ● インジケータ (working=青 / blocked=赤 / idle=緑) を表示します。

## Key Changes

- `.tmux/agent-status.sh` (新規): hook から呼ばれる状態書き込みスクリプト。`$TMUX_PANE` の pane option `@agent_status` を set/unset する。tmux 外では no-op
- `.tmux.conf`: `window-status-format` / `window-status-current-format` に pane ループ `#{P:#{@agent_status}}` を追加。複数タブ並列・1 window 内の pane 分割の両方に対応 (window 間で状態は混ざらない)
- `bin/agent_hooks.sh` (新規): `~/.claude/settings.json` と `~/.codex/hooks.json` への hook 登録 installer。冪等 (再実行で重複しない)・`uninstall` 対応・agent-status 以外の既存 hook (herdr 等) は保持
- `Makefile`: `agent_hooks` / `agent_hooks_uninstall` ターゲットを追加

### イベントマッピング

| 状態 | Claude Code | Codex |
|---|---|---|
| idle (緑) | SessionStart / Stop | SessionStart / Stop |
| working (青) | UserPromptSubmit / PostToolUse | UserPromptSubmit / PostToolUse |
| blocked (赤) | Notification | PermissionRequest |
| clear | SessionEnd | (SessionEnd なし) |

## Impact

- 表示更新は `status-interval 5` 依存のため状態変化から最大 5 秒の遅延あり (hook プロセスから `refresh-client` は効かないため許容)
- Codex の hook イベント名はバイナリの strings 出力から確認したもの (docs 非同梱・experimental)。Codex 側の実機発火は未検証
- `make agent_hooks` 実行までは hook は登録されず、`.tmux.conf` の表示変更のみが効く

## 検証

- `sh -n` / `shellcheck` 両スクリプト PASS
- `tmux -L conftest -f .tmux.conf new-session -d` で conf 読み込み OK
- 使い捨てセッションで 2 pane + 2 window を作成し、pane ごとの ● 表示・window 間非混線・clear での unset を確認
- installer 2 回実行で hook エントリが重複しないこと、`uninstall` で agent-status エントリのみ除去され herdr hook が残ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
