### PR TITLE
feat: Claude Code の hooks と statusline を dotfiles で管理

### DIFF
--- a/.claude/hooks/guard-force-push.sh
+++ b/.claude/hooks/guard-force-push.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# ============================================================================
+# guard-force-push.sh
+#
+# Hook event : PreToolUse
+# Matcher    : Bash
+#
+# 目的:
+#   `git push --force` / `git push -f` 相当のコマンドを hook でブロック。
+#   permissions.deny のパターンマッチは "git -c ... push --force" のような
+#   接頭 flag が付いた形を素通しさせる隙間があるため、意味論ベースで防ぐ。
+#
+# ブロック対象:
+#   - git push ... -f
+#   - git push ... --force
+#   - git push ... --force=<value>
+#
+# 素通し（相対的に安全なので許可）:
+#   - git push --force-with-lease [--force-if-includes]
+#
+# 挙動:
+#   - 該当時は JSON {"decision":"block","reason":"..."} を stdout に出力
+#   - 該当しなければ何も出さず exit 0
+#
+# 入力:
+#   stdin に Claude Code の hook JSON。tool_input.command を参照。
+# ============================================================================
+
+set -eu
+
+cmd=$(jq -r '.tool_input.command // empty')
+
+# 空・非 Bash なら素通し
+[ -z "$cmd" ] && exit 0
+
+# git push を含まないなら素通し
+echo "$cmd" | grep -qE '(^|[[:space:];&|]+)git( +-[^ ]+)*  *push([[:space:];&|]|$)' || exit 0
+
+# --force-with-lease 系は許可（先にホワイトリスト判定）
+if echo "$cmd" | grep -qE '(^| )--force-with-lease($|=| )'; then
+  exit 0
+fi
+
+# -f / --force / --force=<val> を検出
+if echo "$cmd" | grep -qE '(^| )(-f|--force)($|=| )'; then
+  cat <<'EOF'
+{"decision":"block","reason":"guard-force-push: `git push --force` (or -f) is blocked. Prefer `git push --force-with-lease` after confirming with the user, or update the branch via rebase + PR review instead."}
+EOF
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/guard-protected-files.sh
+++ b/.claude/hooks/guard-protected-files.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# ============================================================================
+# guard-protected-files.sh
+#
+# Hook event : PreToolUse
+# Matcher    : Edit | Write | MultiEdit
+#
+# 目的:
+#   Claude Code に「絶対に手編集させたくない」ファイル群への
+#   Edit / Write / MultiEdit をブロックする。
+#   permissions.deny は Read しか制限できないため、書き込み側の
+#   セーフティネットとしてこの hook で対応する。
+#
+# 保護対象:
+#   - .env / .env.<suffix>
+#   - lockfile 系: package-lock.json, yarn.lock, pnpm-lock.yaml,
+#                  Cargo.lock, go.sum, composer.lock
+#   - .git/ 配下（オブジェクトや参照の直接編集）
+#
+# 挙動:
+#   - 該当時は stdout に JSON {"decision":"block","reason":"..."} を出力
+#     → LLM に理由付きで拒否が伝わる（再度別手段を検討する）
+#   - 該当しなければ何も出さず exit 0
+#
+# 入力:
+#   stdin に Claude Code から hook 用の JSON。tool_input.file_path を参照。
+# ============================================================================
+
+set -eu
+
+file_path=$(jq -r '.tool_input.file_path // empty')
+
+# file_path が取れない（別スキーマ）ときは素通し
+[ -z "$file_path" ] && exit 0
+
+# 保護対象パターン
+if echo "$file_path" | grep -qE '(^|/)(\.env(\.[^/]+)?|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock)$|/\.git/'; then
+  cat <<EOF
+{"decision":"block","reason":"guard-protected-files: '$file_path' is a protected file (.env / lockfile / .git). Do not edit directly. If regeneration is needed, run the appropriate package manager or migration command instead, and confirm with the user first."}
+EOF
+  exit 0
+fi
+
+exit 0

--- a/.claude/hooks/notify-sound.sh
+++ b/.claude/hooks/notify-sound.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# ============================================================================
+# notify-sound.sh
+#
+# Hook event : Notification
+#
+# 目的:
+#   Claude Code が操作待ち（承認要求・エラー等）で止まったときに
+#   macOS の afplay で短い効果音を鳴らし、席を外していても気付けるようにする。
+#
+# 備考:
+#   - preferredNotifChannel: 'ghostty' で ghostty 側のバナー通知も併用中。
+#     ghostty 側に音があると二重になるので、音が重複していると感じたら
+#     どちらか片方を無効化する。
+#   - afplay をバックグラウンド実行し、hook 全体は即 exit 0（tmux status
+#     など後続 hook の遅延を避けるため）。
+#
+# 入力:
+#   stdin の JSON は使わない（通知が発火した事実のみで十分）。
+# ============================================================================
+
+set -eu
+
+# 存在しない環境（macOS 以外や afplay 未インストール）では静かに終了
+command -v afplay >/dev/null 2>&1 || exit 0
+
+# Glass はデフォルトで存在する短めのシステム音
+SOUND="/System/Library/Sounds/Ping.aiff"
+[ -f "$SOUND" ] || exit 0
+
+afplay "$SOUND" >/dev/null 2>&1 &
+
+exit 0

--- a/.claude/statusline.sh
+++ b/.claude/statusline.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Claude Code statusline script
+# Shows cost, input/output tokens, and context usage percentage
+#
+# Setup:
+#   Add the following to ~/.claude/settings.json:
+#
+#   {
+#     "statusLine": {
+#       "type": "command",
+#       "command": "/bin/sh /path/to/this/statusline.sh"
+#     }
+#   }
+#
+# Requirements:
+#   - jq (brew install jq)
+
+input=$(cat)
+
+MODEL=$(echo "$input" | jq -r '.model.display_name // "Unknown"')
+COST=$(echo "$input" | jq -r '.cost.total_cost_usd // 0' | xargs printf "%.2f")
+# Format number with k/M suffix
+format_tokens() {
+    awk '{
+        if ($1 >= 1000000) printf "%.1fM", $1/1000000
+        else if ($1 >= 1000) printf "%.1fk", $1/1000
+        else printf "%d", $1
+    }'
+}
+
+INPUT_TOKENS=$(echo "$input" | jq -r '.context_window.total_input_tokens // 0' | format_tokens)
+OUTPUT_TOKENS=$(echo "$input" | jq -r '.context_window.total_output_tokens // 0' | format_tokens)
+CONTEXT_USED=$(echo "$input" | jq -r '.context_window.used_percentage // 0' | xargs printf "%.0f")
+
+# Read current effort level from Claude Code settings.
+# The statusline JSON payload does not expose effortLevel, so we read it
+# directly from the user's settings file (updated by /effort).
+SETTINGS_PATH="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/settings.json"
+if [ -f "$SETTINGS_PATH" ]; then
+    EFFORT=$(jq -r '.effortLevel // "default"' "$SETTINGS_PATH" 2>/dev/null || echo "default")
+else
+    EFFORT="default"
+fi
+
+# ANSI color codes
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+# Color based on context usage
+if [ "${CONTEXT_USED}" -gt 80 ]; then
+    CTX_COLOR=$RED
+elif [ "${CONTEXT_USED}" -gt 60 ]; then
+    CTX_COLOR=$YELLOW
+else
+    CTX_COLOR=$GREEN
+fi
+
+# Color based on effort level
+case "$EFFORT" in
+    high)   EFFORT_COLOR=$RED ;;
+    medium) EFFORT_COLOR=$YELLOW ;;
+    low)    EFFORT_COLOR=$GREEN ;;
+    *)      EFFORT_COLOR=$CYAN ;;
+esac
+
+printf "%b%s%b | \$%s | ⚡%b%s%b | IN:%s OUT:%s | %b%s%%%b\n" \
+    "$CYAN" "$MODEL" "$NC" \
+    "$COST" \
+    "$EFFORT_COLOR" "$EFFORT" "$NC" \
+    "$INPUT_TOKENS" "$OUTPUT_TOKENS" \
+    "$CTX_COLOR" "$CONTEXT_USED" "$NC"

--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,9 @@
 .hammerspoon/hs/libspaces*dylib.dSYM/*
 
 # Coding Agent
-.claude
+.claude/*
+!.claude/hooks/
+!.claude/statusline.sh
 .antigravitycli/
 
 # webdata-node dependencies

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -39,6 +39,8 @@ TARGETS=( \
          ".config/lazygit" \
          ".hammerspoon" \
          ".markdownlint.yml" \
+         ".claude/hooks" \
+         ".claude/statusline.sh" \
        )
 
 for TARGET in ${TARGETS[@]}


### PR DESCRIPTION
## Summary

- これまで `~/.claude/hooks/*.sh` と `~/Project/Personal/coding-agents/claude/statusline.sh` に散在していた Claude Code 用スクリプトを本リポジトリで管理する
- `bin/link.sh` にサブディレクトリ / 個別ファイルの symlink エントリを追加し, `make link` で `~/.claude/hooks` と `~/.claude/statusline.sh` を張るように統合
- `.gitignore` を `.claude/*` + ホワイトリスト方式に変更し, `.claude/hooks/` と `.claude/statusline.sh` のみを track 対象化 (既存の untracked な `.claude/settings.local.json` / `.claude/skills/` は引き続き無視)

## 管理方針

Claude Code と Codex での hook 共用可否を踏まえた整理:

| ファイル | 共用可否 | 配置理由 |
|---|---|---|
| `notify-sound.sh` | agent 非依存 | 現状は Claude だけが使用. Codex 側で必要になったら `~/.claude/hooks/notify-sound.sh` の絶対参照か `agent-hooks/` 切り出しを検討 |
| `guard-protected-files.sh` | Claude 専用 (`.tool_input.file_path` schema 依存) | `.claude/hooks/` に配置 |
| `guard-force-push.sh` | Claude 専用 (`.tool_input.command` schema 依存) | 同上 |
| `statusline.sh` | Claude 専用 (Codex に相当機能なし) | `.claude/statusline.sh` に配置 |
| `agent-status.sh` (既存) | agent 非依存 | 既に `.tmux/` 経由で Codex `hooks.json` と共用済み |

## 手元での追加作業

- `~/.claude/settings.json` の `statusLine.command` を `sh ~/.claude/statusline.sh` に更新済み (このファイルは repo 管理外)
- 旧実体 `~/.claude/hooks/` は `~/.claude/hooks.bak.20260717075926/` に退避済み (動作確認後に削除予定)
- `~/Project/Personal/coding-agents/claude/statusline.sh` は参照されなくなったが物理的には残置 (coding-agents 側は更新されていないとのことなので実害なし)

## Test plan

- [x] `sh -n` で 4 本の shell script の syntax チェック
- [x] `make link` で symlink 化を確認
- [x] `sh ~/.claude/statusline.sh </dev/null` で statusline の smoke test (通常時は Claude Code が JSON を stdin で渡す)
- [ ] マージ後, 新規 Claude Code セッションで hook が発火することを確認 (notification sound / statusline 表示)
- [ ] `.env` へ Edit 試行や `git push -f` 試行でブロックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)