### PR TITLE
feat: Codex Hooks に安全ガードと通知を移植 (#195)

### DIFF
--- a/.agents/hooks/notify-sound.sh
+++ b/.agents/hooks/notify-sound.sh
@@ -2,11 +2,12 @@
 # ============================================================================
 # notify-sound.sh
 #
-# Hook event : Notification
+# Hook event : Claude Code の Notification / Codex の PermissionRequest
 #
 # 目的:
-#   Claude Code が操作待ち（承認要求・エラー等）で止まったときに
+#   エージェントが操作待ち（承認要求・エラー等）で止まったときに
 #   macOS の afplay で短い効果音を鳴らし、席を外していても気付けるようにする。
+#   入力を参照しないため Claude Code と Codex で共用する。
 #
 # 備考:
 #   - preferredNotifChannel: 'ghostty' で ghostty 側のバナー通知も併用中。

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -63,10 +63,31 @@ emit_deny() {
 verdict=$(printf '%s' "$cmd" | awk '
     function ltrim(s) { sub(/^[[:space:]]+/, "", s); return s }
 
-    BEGIN { RS = "[;&|]+" }
+    # 先頭の環境変数代入 (FOO=bar) と env コマンド (env / env FOO=bar) を剥がす。
+    # 剥がした後で "^git" 判定に入るので、`GIT_SSH_COMMAND=... git push --force`
+    # や `env git push -f` も検査対象になる。env に flag が付く形式 (env -i 等)
+    # は対応外（そのケースは検査を素通り、defense-in-depth の限界として許容）。
+    function strip_env(s,   prev) {
+        prev = ""
+        while (s != prev) {
+            prev = s
+            if (match(s, /^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+/)) {
+                s = substr(s, RLENGTH + 1)
+                continue
+            }
+            if (match(s, /^env[[:space:]]+/)) {
+                s = substr(s, RLENGTH + 1)
+                continue
+            }
+        }
+        return s
+    }
+
+    # 改行 (\n) も ; と同等のコマンド区切りとして扱う (Bash 準拠)。
+    BEGIN { RS = "[;&|\n]+" }
 
     {
-        line = ltrim($0)
+        line = strip_env(ltrim($0))
         # `git ...push ...` の形を持つサブコマンドだけ評価。
         # git と push の間には任意個の flag / value トークンを許容する。
         if (line !~ /^git([[:space:]]+[^[:space:]]+)*[[:space:]]+push([[:space:]]|$)/) next
@@ -75,6 +96,11 @@ verdict=$(printf '%s' "$cmd" | awk '
         args = line
         sub(/^git([[:space:]]+[^[:space:]]+)*[[:space:]]+push/, "", args)
         args = ltrim(args)
+        # シェルは実行時に quote を除去して git に argv を渡すため、引用符を
+        # 事前に取り除いてから判定する。`git push "--force"` / `git push origin
+        # "+main"` / `git push '\''--force-with-lease'\'' --force` 等の quote 混在も
+        # raw / plus / combined として拾えるようになる。
+        gsub(/["'\'']/, "", args)
         args_padded = " " args " "  # 前後 padding で境界マッチを簡潔化
 
         has_raw_force = 0

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -12,6 +12,7 @@
 #
 # 拒否対象:
 #   - git push -f / --force / --force=<val>
+#   - -uf / -fu 等、短縮オプションの結合形に f を含むもの
 #   - --force-with-lease と raw force を併記したケース（意図が矛盾するため raw force 側を優先して拒否）
 #   - git push --mirror
 #   - +<refspec> による強制更新（例: git push origin +main）
@@ -27,6 +28,14 @@
 #
 # 入力:
 #   stdin に Codex の hook JSON。.tool_input.command を参照。
+#
+# 実装メモ:
+#   複数コマンド (`;` / `&&` / `||` / `|`) を含む入力に対応するため、
+#   まず command を separator で分割し、各サブコマンドが `git ... push`
+#   であるものだけを取り出す。以降の判定はサブコマンドの push 以降の
+#   引数列に限定して行う（他コマンドの引数に含まれる `--force` などを
+#   偽陽性で拾わないため、および先頭に現れる危険な push を貪欲マッチで
+#   飛ばさないため）。
 # ============================================================================
 
 # shellcheck disable=SC2016  # 拒否メッセージ内の backtick は markdown 装飾で意図的
@@ -36,10 +45,6 @@ cmd=$(jq -r '.tool_input.command // empty')
 
 # 空・非 Bash なら素通し
 [ -z "$cmd" ] && exit 0
-
-# git push を含まないなら素通し。git と push の間に任意の flag / value トークンを許容する
-# （例: `git -c foo=bar push --force`）。; / & / | は command 境界とみなす。
-echo "$cmd" | grep -qE '(^|[[:space:];&|])git([[:space:]]+[^[:space:];&|]+)*[[:space:]]+push([[:space:];&|]|$)' || exit 0
 
 emit_deny() {
     reason="guard-force-push: $1"
@@ -53,39 +58,72 @@ emit_deny() {
     exit 0
 }
 
-has_raw_force=false
-if echo "$cmd" | grep -qE '(^| )(-f|--force)($|=| )'; then
-    has_raw_force=true
-fi
+# サブコマンドごとに push 引数を評価する。1 つでも危険な形が見つかれば拒否。
+# awk は 1 変数のみ入力として扱うため、command 全体を stdin から流し込む。
+verdict=$(printf '%s' "$cmd" | awk '
+    function ltrim(s) { sub(/^[[:space:]]+/, "", s); return s }
 
-has_with_lease=false
-if echo "$cmd" | grep -qE '(^| )--force-with-lease($|=| )'; then
-    has_with_lease=true
-fi
+    BEGIN { RS = "[;&|]+" }
 
-# raw force と --force-with-lease の併記は raw force 側を優先して拒否
-if [ "$has_raw_force" = true ] && [ "$has_with_lease" = true ]; then
-    emit_deny 'raw --force と --force-with-lease の併記は意図が矛盾するため拒否します。--force-with-lease 単独に絞ってください。'
-fi
+    {
+        line = ltrim($0)
+        # `git ...push ...` の形を持つサブコマンドだけ評価。
+        # git と push の間には任意個の flag / value トークンを許容する。
+        if (line !~ /^git([[:space:]]+[^[:space:]]+)*[[:space:]]+push([[:space:]]|$)/) next
 
-# raw force
-if [ "$has_raw_force" = true ]; then
-    emit_deny '`git push --force` (or -f) is blocked. Prefer `git push --force-with-lease` after confirming with the user, or update the branch via rebase + PR review instead.'
-fi
+        # push 以降の引数列を取り出す（push の直後の空白より後 or 末尾）
+        args = line
+        sub(/^git([[:space:]]+[^[:space:]]+)*[[:space:]]+push/, "", args)
+        args = ltrim(args)
+        args_padded = " " args " "  # 前後 padding で境界マッチを簡潔化
 
-# --mirror
-if echo "$cmd" | grep -qE '(^| )--mirror($| )'; then
-    emit_deny '`git push --mirror` は全 ref を上書きするため拒否します。個別 branch を明示的に push してください。'
-fi
+        has_raw_force = 0
+        has_with_lease = 0
 
-# +<refspec> による強制更新: git push <remote> +<ref>[:<ref>] を検出
-# push サブコマンド以降の位置引数を評価する必要があるため簡略化:
-# コマンド全体に " +<非空白>" もしくは "^+<非空白>" が現れ、
-# それが git push の refspec 位置に相当するかを判定する。
-# 誤検知を避けるため、"push" 以降の部分だけを対象にする。
-push_tail=$(echo "$cmd" | sed -n 's/.*[[:space:]]push\([[:space:]].*\)/\1/p')
-if [ -n "$push_tail" ] && echo "$push_tail" | grep -qE '(^|[[:space:]])\+[^[:space:]]+'; then
-    emit_deny '`+<refspec>` による強制更新は拒否します。lease 付きで push するか, rebase + PR review を経由してください。'
-fi
+        # --force / --force=<val>
+        if (args_padded ~ /[[:space:]]--force([[:space:]]|=)/) has_raw_force = 1
+        # 短縮結合形 -f / -uf / -fu / -abcf など (単ダッシュで f を含み等号なし)
+        if (args_padded ~ /[[:space:]]-[[:alnum:]]*f[[:alnum:]]*[[:space:]]/) has_raw_force = 1
+
+        # --force-with-lease
+        if (args_padded ~ /[[:space:]]--force-with-lease([[:space:]]|=)/) has_with_lease = 1
+
+        if (has_raw_force && has_with_lease) {
+            print "combined"
+            exit
+        }
+        if (has_raw_force) {
+            print "raw"
+            exit
+        }
+
+        # --mirror
+        if (args_padded ~ /[[:space:]]--mirror[[:space:]]/) {
+            print "mirror"
+            exit
+        }
+
+        # +<refspec>: token whose first non-blank char is +
+        if (args_padded ~ /[[:space:]]\+[^[:space:]]+[[:space:]]/) {
+            print "plus"
+            exit
+        }
+    }
+')
+
+case "$verdict" in
+    combined)
+        emit_deny 'raw --force と --force-with-lease の併記は意図が矛盾するため拒否します。--force-with-lease 単独に絞ってください。'
+        ;;
+    raw)
+        emit_deny '`git push --force` (or -f / -uf など短縮結合形) is blocked. Prefer `git push --force-with-lease` after confirming with the user, or update the branch via rebase + PR review instead.'
+        ;;
+    mirror)
+        emit_deny '`git push --mirror` は全 ref を上書きするため拒否します。個別 branch を明示的に push してください。'
+        ;;
+    plus)
+        emit_deny '`+<refspec>` による強制更新は拒否します。lease 付きで push するか, rebase + PR review を経由してください。'
+        ;;
+esac
 
 exit 0

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -142,20 +142,48 @@ verdict=$(printf '%s' "$cmd" | awk '
         return r
     }
 
-    function check_subcommand(line,   n, tok, i, pos, args, args_padded, has_raw_force, has_with_lease) {
+    # git global option のうち、次 token を値として consume するもの。
+    # 空白区切りで値を取る形式 (`--git-dir /path`) と attached 形式
+    # (`--git-dir=/path`) の両方が git で受理されるため、両対応する。
+    # attached 形式は先頭に `=` を含むので `-` 判定だけで自然に flag 扱いになる。
+    function takes_separate_value(t) {
+        return (t == "-c" || t == "-C" ||
+                t == "--git-dir" || t == "--work-tree" ||
+                t == "--namespace" || t == "--super-prefix" ||
+                t == "--config-env")
+    }
+
+    # 先頭に現れうる shell control keyword / 記号。
+    # subshell paren は RS で separator にしているので tok として現れないが、
+    # `{`, `}`, `!`, `time`, if/then/else/... は tok として残りうる。
+    function is_shell_control(t) {
+        return (t == "!" || t == "time" ||
+                t == "if" || t == "then" || t == "else" || t == "elif" || t == "fi" ||
+                t == "do" || t == "done" || t == "while" || t == "until" ||
+                t == "for" || t == "case" || t == "in" || t == "esac" ||
+                t == "{" || t == "}")
+    }
+
+    function check_subcommand(line,   n, tok, i, pos, start, args, args_padded, has_raw_force, has_with_lease) {
         line = strip_env(ltrim(line))
         n = split(line, tok, /[[:space:]]+/)
-        if (n == 0 || tok[1] != "git") return ""
-        # git の直後: グローバル option (-c VAL / -C dir / --xxx / -x) を読み飛ばし、
-        # 最初に現れる bare token を "git のサブコマンド" として扱う。それが
-        # "push" のときのみ検査対象。`git checkout push --force` のような
-        # 別サブコマンドの引数に "push" が現れても push subcommand と誤認しない。
-        i = 2
+        if (n == 0) return ""
+        # 先頭の shell control token (if / then / do / { など) を読み飛ばす。
+        # `if true; then git push -f ...; fi` のように制御構文で囲まれた
+        # 実コマンドも subcommand として検査対象にする。
+        start = 1
+        while (start <= n && is_shell_control(tok[start])) start++
+        if (start > n || tok[start] != "git") return ""
+        # git の直後: グローバル option (-c VAL / -C dir / --git-dir DIR / --xxx / -x)
+        # を読み飛ばし、最初に現れる bare token を git subcommand として扱う。
+        # `git checkout push --force` のような別 subcommand の引数に "push" が
+        # 現れても push subcommand と誤認しない。
+        i = start + 1
         pos = 0
         while (i <= n) {
             if (substr(tok[i], 1, 1) == "-") {
-                # flag。-c と -C は次 token を値として消費する。
-                if (tok[i] == "-c" || tok[i] == "-C") {
+                # flag。next token を値として consume する global option は 2 token 進める。
+                if (takes_separate_value(tok[i])) {
                     i += 2
                 } else {
                     i += 1
@@ -205,7 +233,10 @@ verdict=$(printf '%s' "$cmd" | awk '
         # 分割対象の改行から除外する必要がある。
         gsub(/\\\n/, " ", input)
         neutralized = neutralize_sq(input)
-        n = split(neutralized, subs, /[;&|\n]+/)
+        # subshell paren `(cmd)` の内側も subcommand として検査対象にするため、
+        # `(` / `)` も separator に含める。制御構文の keyword (if / then / do
+        # など) は tok ベースで check_subcommand が読み飛ばすので RS には不要。
+        n = split(neutralized, subs, /[;&|\n()]+/)
         for (i = 1; i <= n; i++) {
             v = check_subcommand(subs[i])
             if (v != "") { print v; exit }

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -1,0 +1,91 @@
+#!/bin/sh
+# ============================================================================
+# guard-force-push.sh
+#
+# Hook event : PreToolUse
+# Matcher    : ^Bash$
+#
+# 目的:
+#   Codex の Bash tool で、危険な force push を拒否する。
+#   permissions のパターンマッチは "git -c ... push --force" のような
+#   接頭 flag が付いた形を素通しさせる隙間があるため、意味論ベースで防ぐ。
+#
+# 拒否対象:
+#   - git push -f / --force / --force=<val>
+#   - --force-with-lease と raw force を併記したケース（意図が矛盾するため raw force 側を優先して拒否）
+#   - git push --mirror
+#   - +<refspec> による強制更新（例: git push origin +main）
+#
+# 許可:
+#   - git push --force-with-lease [--force-if-includes]
+#   - git push --force-if-includes 単独（lease がない場合は Git 上 no-op）
+#   - 通常の git push
+#
+# 挙動:
+#   - 該当時は hookSpecificOutput.permissionDecision=deny を JSON で stdout に出力
+#   - 該当しなければ何も出さず exit 0（終了コードは常に 0）
+#
+# 入力:
+#   stdin に Codex の hook JSON。.tool_input.command を参照。
+# ============================================================================
+
+# shellcheck disable=SC2016  # 拒否メッセージ内の backtick は markdown 装飾で意図的
+set -eu
+
+cmd=$(jq -r '.tool_input.command // empty')
+
+# 空・非 Bash なら素通し
+[ -z "$cmd" ] && exit 0
+
+# git push を含まないなら素通し。git と push の間に任意の flag / value トークンを許容する
+# （例: `git -c foo=bar push --force`）。; / & / | は command 境界とみなす。
+echo "$cmd" | grep -qE '(^|[[:space:];&|])git([[:space:]]+[^[:space:];&|]+)*[[:space:]]+push([[:space:];&|]|$)' || exit 0
+
+emit_deny() {
+    reason="guard-force-push: $1"
+    jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }'
+    exit 0
+}
+
+has_raw_force=false
+if echo "$cmd" | grep -qE '(^| )(-f|--force)($|=| )'; then
+    has_raw_force=true
+fi
+
+has_with_lease=false
+if echo "$cmd" | grep -qE '(^| )--force-with-lease($|=| )'; then
+    has_with_lease=true
+fi
+
+# raw force と --force-with-lease の併記は raw force 側を優先して拒否
+if [ "$has_raw_force" = true ] && [ "$has_with_lease" = true ]; then
+    emit_deny 'raw --force と --force-with-lease の併記は意図が矛盾するため拒否します。--force-with-lease 単独に絞ってください。'
+fi
+
+# raw force
+if [ "$has_raw_force" = true ]; then
+    emit_deny '`git push --force` (or -f) is blocked. Prefer `git push --force-with-lease` after confirming with the user, or update the branch via rebase + PR review instead.'
+fi
+
+# --mirror
+if echo "$cmd" | grep -qE '(^| )--mirror($| )'; then
+    emit_deny '`git push --mirror` は全 ref を上書きするため拒否します。個別 branch を明示的に push してください。'
+fi
+
+# +<refspec> による強制更新: git push <remote> +<ref>[:<ref>] を検出
+# push サブコマンド以降の位置引数を評価する必要があるため簡略化:
+# コマンド全体に " +<非空白>" もしくは "^+<非空白>" が現れ、
+# それが git push の refspec 位置に相当するかを判定する。
+# 誤検知を避けるため、"push" 以降の部分だけを対象にする。
+push_tail=$(echo "$cmd" | sed -n 's/.*[[:space:]]push\([[:space:]].*\)/\1/p')
+if [ -n "$push_tail" ] && echo "$push_tail" | grep -qE '(^|[[:space:]])\+[^[:space:]]+'; then
+    emit_deny '`+<refspec>` による強制更新は拒否します。lease 付きで push するか, rebase + PR review を経由してください。'
+fi
+
+exit 0

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -15,7 +15,7 @@
 #   - -uf / -fu 等、短縮オプションの結合形に f を含むもの
 #   - --force-with-lease と raw force を併記したケース（意図が矛盾するため raw force 側を優先して拒否）
 #   - git push --mirror
-#   - +<refspec> による強制更新（例: git push origin +main）
+#   - +<refspec>: 引数中の + で始まる token（強制更新）
 #
 # 許可:
 #   - git push --force-with-lease [--force-if-includes]
@@ -30,12 +30,24 @@
 #   stdin に Codex の hook JSON。.tool_input.command を参照。
 #
 # 実装メモ:
-#   複数コマンド (`;` / `&&` / `||` / `|`) を含む入力に対応するため、
-#   まず command を separator で分割し、各サブコマンドが `git ... push`
-#   であるものだけを取り出す。以降の判定はサブコマンドの push 以降の
-#   引数列に限定して行う（他コマンドの引数に含まれる `--force` などを
-#   偽陽性で拾わないため、および先頭に現れる危険な push を貪欲マッチで
-#   飛ばさないため）。
+#   1. command 全体を単一 record として読み、シングルクォート内の separator
+#      (; / & / | / \n) を空白に neutralize してから subcommand 分割する。
+#      これにより `echo 'x;git push --force ...'` のような単なる文字列引数を
+#      subcommand として誤検出しない。
+#   2. 各 subcommand は先頭の env-var 代入 / env コマンドを剥がしてから
+#      whitespace で token 化し、tok[1]=='git' かつ最初の 'push' token を
+#      subcommand 位置として扱う。POSIX awk の longest-match による
+#      `git push --force origin push` (refspec 名が push) のような bypass を
+#      避けるため。
+#   3. token 化後の args から quote (' / ") を除去してから regex 判定する。
+#      シェル実行時に quote が除去されて git に argv として渡るため。
+#
+# 既知の限界（defense-in-depth の限界として明示的に許容）:
+#   - ダブルクォート内・ヒアドキュメント内の separator は neutralize しない
+#     ため、`echo "x;git push --force ..."` のような入力は分割されて誤検出
+#     する（false positive: 実際には実行されない）。
+#   - `env -i git push --force` のように env に flag が付く形式は先頭の
+#     env-var stripping を通過しないので検査対象外になる（false negative）。
 # ============================================================================
 
 # shellcheck disable=SC2016  # 拒否メッセージ内の backtick は markdown 装飾で意図的
@@ -58,15 +70,13 @@ emit_deny() {
     exit 0
 }
 
-# サブコマンドごとに push 引数を評価する。1 つでも危険な形が見つかれば拒否。
-# awk は 1 変数のみ入力として扱うため、command 全体を stdin から流し込む。
 verdict=$(printf '%s' "$cmd" | awk '
     function ltrim(s) { sub(/^[[:space:]]+/, "", s); return s }
 
     # 先頭の環境変数代入 (FOO=bar) と env コマンド (env / env FOO=bar) を剥がす。
     # 剥がした後で "^git" 判定に入るので、`GIT_SSH_COMMAND=... git push --force`
     # や `env git push -f` も検査対象になる。env に flag が付く形式 (env -i 等)
-    # は対応外（そのケースは検査を素通り、defense-in-depth の限界として許容）。
+    # は未対応（defense-in-depth の限界として document 済み）。
     function strip_env(s,   prev) {
         prev = ""
         while (s != prev) {
@@ -83,25 +93,45 @@ verdict=$(printf '%s' "$cmd" | awk '
         return s
     }
 
-    # 改行 (\n) も ; と同等のコマンド区切りとして扱う (Bash 準拠)。
-    BEGIN { RS = "[;&|\n]+" }
+    # シングルクォート (\047) 内の separator を空白に置換する。Bash の
+    # シングルクォートはあらゆる展開を無効化するため、内部を単なる文字列と
+    # して扱ってよい。ダブルクォート・ヒアドキュメントは $(...) や `...`
+    # command substitution を含みうるので neutralize しない。
+    function neutralize_sq(s,   r, i, n, c, in_sq) {
+        r = ""
+        n = length(s)
+        in_sq = 0
+        for (i = 1; i <= n; i++) {
+            c = substr(s, i, 1)
+            if (c == "\047") { in_sq = 1 - in_sq; r = r c; continue }
+            if (in_sq && (c == ";" || c == "&" || c == "|" || c == "\n")) {
+                r = r " "
+                continue
+            }
+            r = r c
+        }
+        return r
+    }
 
-    {
-        line = strip_env(ltrim($0))
-        # `git ...push ...` の形を持つサブコマンドだけ評価。
-        # git と push の間には任意個の flag / value トークンを許容する。
-        if (line !~ /^git([[:space:]]+[^[:space:]]+)*[[:space:]]+push([[:space:]]|$)/) next
+    function check_subcommand(line,   n, tok, i, pos, args, args_padded, has_raw_force, has_with_lease) {
+        line = strip_env(ltrim(line))
+        n = split(line, tok, /[[:space:]]+/)
+        if (n == 0 || tok[1] != "git") return ""
+        # git の直後で最初に現れる "push" token を subcommand 位置と扱う。
+        # tok[1] は "git" 固定なので i は 2 から探す。
+        pos = 0
+        for (i = 2; i <= n; i++) {
+            if (tok[i] == "push") { pos = i; break }
+        }
+        if (pos == 0) return ""
 
-        # push 以降の引数列を取り出す（push の直後の空白より後 or 末尾）
-        args = line
-        sub(/^git([[:space:]]+[^[:space:]]+)*[[:space:]]+push/, "", args)
-        args = ltrim(args)
-        # シェルは実行時に quote を除去して git に argv を渡すため、引用符を
-        # 事前に取り除いてから判定する。`git push "--force"` / `git push origin
-        # "+main"` / `git push '\''--force-with-lease'\'' --force` 等の quote 混在も
-        # raw / plus / combined として拾えるようになる。
-        gsub(/["'\'']/, "", args)
-        args_padded = " " args " "  # 前後 padding で境界マッチを簡潔化
+        # push 以降の tokens を args として結合し、quote を除去する。
+        args = ""
+        for (i = pos + 1; i <= n; i++) {
+            args = (args == "") ? tok[i] : args " " tok[i]
+        }
+        gsub(/["\047]/, "", args)
+        args_padded = " " args " "
 
         has_raw_force = 0
         has_with_lease = 0
@@ -114,25 +144,24 @@ verdict=$(printf '%s' "$cmd" | awk '
         # --force-with-lease
         if (args_padded ~ /[[:space:]]--force-with-lease([[:space:]]|=)/) has_with_lease = 1
 
-        if (has_raw_force && has_with_lease) {
-            print "combined"
-            exit
-        }
-        if (has_raw_force) {
-            print "raw"
-            exit
-        }
+        if (has_raw_force && has_with_lease) return "combined"
+        if (has_raw_force) return "raw"
+        if (args_padded ~ /[[:space:]]--mirror[[:space:]]/) return "mirror"
+        if (args_padded ~ /[[:space:]]\+[^[:space:]]+[[:space:]]/) return "plus"
+        return ""
+    }
 
-        # --mirror
-        if (args_padded ~ /[[:space:]]--mirror[[:space:]]/) {
-            print "mirror"
-            exit
-        }
+    # 全 record を単一 buffer に蓄積してから処理する。awk のデフォルト RS
+    # では入力の改行が record 境界になり、シングルクォート内の改行判定が
+    # できないため。
+    { input = (NR == 1 ? $0 : input "\n" $0) }
 
-        # +<refspec>: token whose first non-blank char is +
-        if (args_padded ~ /[[:space:]]\+[^[:space:]]+[[:space:]]/) {
-            print "plus"
-            exit
+    END {
+        neutralized = neutralize_sq(input)
+        n = split(neutralized, subs, /[;&|\n]+/)
+        for (i = 1; i <= n; i++) {
+            v = check_subcommand(subs[i])
+            if (v != "") { print v; exit }
         }
     }
 ')

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -164,16 +164,22 @@ verdict=$(printf '%s' "$cmd" | awk '
                 t == "{" || t == "}")
     }
 
-    function check_subcommand(line,   n, tok, i, pos, start, args, args_padded, has_raw_force, has_with_lease) {
+    function check_subcommand(line,   n, tok, i, j, t, pos, start, has_raw_force, has_with_lease, has_mirror, has_plus) {
         line = strip_env(ltrim(line))
         n = split(line, tok, /[[:space:]]+/)
         if (n == 0) return ""
-        # 先頭の shell control token (if / then / do / { など) を読み飛ばす。
-        # `if true; then git push -f ...; fi` のように制御構文で囲まれた
-        # 実コマンドも subcommand として検査対象にする。
+        # 先頭の shell control token (if / then / do / { など) と shell
+        # wrapper (command / exec / builtin) を読み飛ばす。
+        # `if true; then git push -f ...; fi` や `command git push --force`
+        # のようなケースも subcommand として検査対象にする。
         start = 1
-        while (start <= n && is_shell_control(tok[start])) start++
-        if (start > n || tok[start] != "git") return ""
+        while (start <= n && (is_shell_control(tok[start]) ||
+                              tok[start] == "command" || tok[start] == "exec" ||
+                              tok[start] == "builtin")) start++
+        if (start > n) return ""
+        # git 本体は "git" or "<path>/git" 形式で受け付ける
+        # (`/usr/bin/git push --force` などの絶対パス呼び出しに対応)。
+        if (tok[start] != "git" && tok[start] !~ /(^|\/)git$/) return ""
         # git の直後: グローバル option (-c VAL / -C dir / --git-dir DIR / --xxx / -x)
         # を読み飛ばし、最初に現れる bare token を git subcommand として扱う。
         # `git checkout push --force` のような別 subcommand の引数に "push" が
@@ -196,29 +202,36 @@ verdict=$(printf '%s' "$cmd" | awk '
         }
         if (pos == 0) return ""
 
-        # push 以降の tokens を args として結合し、quote を除去する。
-        args = ""
-        for (i = pos + 1; i <= n; i++) {
-            args = (args == "") ? tok[i] : args " " tok[i]
-        }
-        gsub(/["\047]/, "", args)
-        args_padded = " " args " "
-
+        # push 以降の tokens を 1 つずつ判定する。
+        # トークン単位の判定にすることで、`-ofoo` (push-option の値埋め込み) を
+        # `-f を含む短縮結合形` と誤認する false positive を避ける。
         has_raw_force = 0
         has_with_lease = 0
+        has_mirror = 0
+        has_plus = 0
+        for (j = pos + 1; j <= n; j++) {
+            t = tok[j]
+            gsub(/["\047]/, "", t)  # quote 除去
 
-        # --force / --force=<val>
-        if (args_padded ~ /[[:space:]]--force([[:space:]]|=)/) has_raw_force = 1
-        # 短縮結合形 -f / -uf / -fu / -abcf など (単ダッシュで f を含み等号なし)
-        if (args_padded ~ /[[:space:]]-[[:alnum:]]*f[[:alnum:]]*[[:space:]]/) has_raw_force = 1
-
-        # --force-with-lease
-        if (args_padded ~ /[[:space:]]--force-with-lease([[:space:]]|=)/) has_with_lease = 1
+            # --force / --force=<val>
+            if (t == "--force" || t ~ /^--force=/) { has_raw_force = 1; continue }
+            # 短縮結合形: 値を取らない git push short flag [f v q n u d] のみで
+            # 構成された cluster に f が 1 文字以上含まれる場合のみ raw force。
+            # 値を取る -o (push-option) は cluster に含めない: `-ofoo` は
+            # `--push-option=foo` の短縮であり `-f` の結合形ではない。
+            if (t ~ /^-[fvqnud]*f[fvqnud]*$/) { has_raw_force = 1; continue }
+            # --force-with-lease
+            if (t == "--force-with-lease" || t ~ /^--force-with-lease=/) { has_with_lease = 1; continue }
+            # --mirror
+            if (t == "--mirror") { has_mirror = 1; continue }
+            # +<refspec>
+            if (substr(t, 1, 1) == "+" && length(t) > 1) { has_plus = 1; continue }
+        }
 
         if (has_raw_force && has_with_lease) return "combined"
         if (has_raw_force) return "raw"
-        if (args_padded ~ /[[:space:]]--mirror[[:space:]]/) return "mirror"
-        if (args_padded ~ /[[:space:]]\+[^[:space:]]+[[:space:]]/) return "plus"
+        if (has_mirror) return "mirror"
+        if (has_plus) return "plus"
         return ""
     }
 

--- a/.codex/hooks/guard-force-push.sh
+++ b/.codex/hooks/guard-force-push.sh
@@ -73,22 +73,51 @@ emit_deny() {
 verdict=$(printf '%s' "$cmd" | awk '
     function ltrim(s) { sub(/^[[:space:]]+/, "", s); return s }
 
-    # 先頭の環境変数代入 (FOO=bar) と env コマンド (env / env FOO=bar) を剥がす。
-    # 剥がした後で "^git" 判定に入るので、`GIT_SSH_COMMAND=... git push --force`
-    # や `env git push -f` も検査対象になる。env に flag が付く形式 (env -i 等)
-    # は未対応（defense-in-depth の限界として document 済み）。
-    function strip_env(s,   prev) {
+    # 先頭の環境変数代入 (FOO=bar / FOO=<quoted-with-spaces>) と env コマンドを剥がす。
+    # 剥がした後で tok[1] == git 判定に入るので、
+    # `GIT_SSH_COMMAND=... git push --force` や `env git push -f`
+    # (値に quote 込み空白を含む形も含む) を検査対象にできる。
+    # env に flag が付く形式 (env -i 等) は未対応（defense-in-depth の限界）。
+    function strip_env(s,   prev, i, n, c, eq_len, in_q, q_char) {
         prev = ""
         while (s != prev) {
             prev = s
-            if (match(s, /^[A-Za-z_][A-Za-z0-9_]*=[^[:space:]]*[[:space:]]+/)) {
-                s = substr(s, RLENGTH + 1)
-                continue
-            }
             if (match(s, /^env[[:space:]]+/)) {
                 s = substr(s, RLENGTH + 1)
                 continue
             }
+            if (!match(s, /^[A-Za-z_][A-Za-z0-9_]*=/)) break
+            eq_len = RLENGTH
+            # 値部分を quote-aware に消費する: unquoted whitespace で終端。
+            i = eq_len + 1
+            n = length(s)
+            in_q = 0
+            q_char = ""
+            while (i <= n) {
+                c = substr(s, i, 1)
+                if (in_q) {
+                    if (c == q_char) { in_q = 0; q_char = "" }
+                    i++
+                    continue
+                }
+                if (c == "\047" || c == "\"") {
+                    in_q = 1
+                    q_char = c
+                    i++
+                    continue
+                }
+                if (c == " " || c == "\t") break
+                i++
+            }
+            # 末尾に達している = 後続の command がないので strip 対象外として抜ける
+            if (i > n) break
+            # 値終端後の連続空白を飛ばす
+            while (i <= n) {
+                c = substr(s, i, 1)
+                if (c == " " || c == "\t") { i++; continue }
+                break
+            }
+            s = substr(s, i)
         }
         return s
     }
@@ -117,11 +146,25 @@ verdict=$(printf '%s' "$cmd" | awk '
         line = strip_env(ltrim(line))
         n = split(line, tok, /[[:space:]]+/)
         if (n == 0 || tok[1] != "git") return ""
-        # git の直後で最初に現れる "push" token を subcommand 位置と扱う。
-        # tok[1] は "git" 固定なので i は 2 から探す。
+        # git の直後: グローバル option (-c VAL / -C dir / --xxx / -x) を読み飛ばし、
+        # 最初に現れる bare token を "git のサブコマンド" として扱う。それが
+        # "push" のときのみ検査対象。`git checkout push --force` のような
+        # 別サブコマンドの引数に "push" が現れても push subcommand と誤認しない。
+        i = 2
         pos = 0
-        for (i = 2; i <= n; i++) {
-            if (tok[i] == "push") { pos = i; break }
+        while (i <= n) {
+            if (substr(tok[i], 1, 1) == "-") {
+                # flag。-c と -C は次 token を値として消費する。
+                if (tok[i] == "-c" || tok[i] == "-C") {
+                    i += 2
+                } else {
+                    i += 1
+                }
+                continue
+            }
+            # 最初の bare token: これが subcommand。
+            if (tok[i] == "push") pos = i
+            break
         }
         if (pos == 0) return ""
 
@@ -157,6 +200,10 @@ verdict=$(printf '%s' "$cmd" | awk '
     { input = (NR == 1 ? $0 : input "\n" $0) }
 
     END {
+        # Bash の行継続 (backslash + newline) を単一空白に正規化してから
+        # subcommand 分割する。行継続はシェル上は 1 コマンド扱いなので、
+        # 分割対象の改行から除外する必要がある。
+        gsub(/\\\n/, " ", input)
         neutralized = neutralize_sq(input)
         n = split(neutralized, subs, /[;&|\n]+/)
         for (i = 1; i <= n; i++) {

--- a/.codex/hooks/guard-protected-apply-patch.sh
+++ b/.codex/hooks/guard-protected-apply-patch.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+# ============================================================================
+# guard-protected-apply-patch.sh
+#
+# Hook event : PreToolUse
+# Matcher    : ^apply_patch$
+#
+# 目的:
+#   Codex の apply_patch tool で、保護対象ファイル群への変更を拒否する。
+#   Codex は apply_patch の入力を .tool_input.command にパッチ全文として渡す
+#   ため、ヘッダーから対象パスを抽出して判定する。
+#
+# 保護対象:
+#   - .env / .env.<suffix>
+#   - lockfile 系: package-lock.json, yarn.lock, pnpm-lock.yaml,
+#                  Cargo.lock, go.sum, composer.lock
+#   - .git/ 配下
+#
+# 解析するヘッダー:
+#   *** Add File: <path>
+#   *** Update File: <path>
+#   *** Delete File: <path>
+#   *** Move to: <path>
+#
+# 挙動:
+#   - いずれかのパスが保護対象なら hookSpecificOutput.permissionDecision=deny
+#     を JSON で stdout に出力する（終了コードは常に 0）
+#   - 該当しなければ何も出さず exit 0
+#
+# 入力:
+#   stdin に Codex から hook 用の JSON。.tool_input.command を参照。
+# ============================================================================
+
+set -eu
+
+command=$(jq -r '.tool_input.command // empty')
+
+# command が取れない（別スキーマ）ときは素通し
+[ -z "$command" ] && exit 0
+
+protected_pattern='(^|/)(\.env(\.[^/]+)?|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock)$|(^|/)\.git(/|$)'
+
+# パッチヘッダーから対象パスを抽出（* 4種のいずれか）
+paths=$(printf '%s\n' "$command" | sed -n \
+    -e 's/^\*\*\* Add File: //p' \
+    -e 's/^\*\*\* Update File: //p' \
+    -e 's/^\*\*\* Delete File: //p' \
+    -e 's/^\*\*\* Move to: //p')
+
+[ -z "$paths" ] && exit 0
+
+hit=$(printf '%s\n' "$paths" | grep -E "$protected_pattern" | head -n 1 || true)
+
+if [ -n "$hit" ]; then
+    reason="guard-protected-apply-patch: '$hit' is a protected file (.env / lockfile / .git). Do not edit directly. If regeneration is needed, run the appropriate package manager or migration command instead, and confirm with the user first."
+    jq -n --arg reason "$reason" '{
+        hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: $reason
+        }
+    }'
+    exit 0
+fi
+
+exit 0

--- a/bin/agent_hooks.sh
+++ b/bin/agent_hooks.sh
@@ -1,9 +1,15 @@
 #!/bin/sh
 
-# Install / uninstall AI agent status hooks for Claude Code and Codex.
-# Registers ~/.tmux/agent-status.sh as a hook command so that each CLI
-# reports its state (working / blocked / idle) to the tmux status line.
-# Existing hook entries that do not reference agent-status.sh are preserved.
+# Install / uninstall AI agent hooks for Claude Code and Codex.
+#
+# Manages:
+#   - tmux status hooks (agent-status.sh) for both CLIs
+#   - shared notification sound (~/.agents/hooks/notify-sound.sh)
+#   - Codex-only protected-file and force-push guards
+#
+# Unrelated hook entries (e.g. Claude Code's existing guard-protected-files.sh
+# / guard-force-push.sh under ~/.claude/hooks/) are preserved on both install
+# and uninstall. Managed entries are identified by command-string substrings.
 #
 # Usage: agent_hooks.sh [uninstall]
 
@@ -25,92 +31,130 @@ if ! command -v jq >/dev/null 2>&1; then
     exit 1
 fi
 
-SCRIPT="$HOME/.tmux/agent-status.sh"
+TMUX_SCRIPT="$HOME/.tmux/agent-status.sh"
+NOTIFY_SCRIPT="$HOME/.agents/hooks/notify-sound.sh"
+CODEX_GUARD_APPLY="$HOME/.codex/hooks/guard-protected-apply-patch.sh"
+CODEX_GUARD_BASH="$HOME/.codex/hooks/guard-force-push.sh"
 
-if [ "$MODE" = "install" ] && [ ! -e "$SCRIPT" ]; then
-    echo "error: $SCRIPT not found. Run 'make link' first." >&2
-    exit 1
+if [ "$MODE" = "install" ]; then
+    for p in "$TMUX_SCRIPT" "$NOTIFY_SCRIPT" "$CODEX_GUARD_APPLY" "$CODEX_GUARD_BASH"; do
+        if [ ! -e "$p" ]; then
+            echo "error: $p not found. Run 'make link' first." >&2
+            exit 1
+        fi
+    done
 fi
 
-# event -> state mapping. Codex has no SessionEnd and uses PermissionRequest
-# where Claude uses Notification.
-CLAUDE_EVENTS='{
-    "SessionStart": "idle",
-    "Stop": "idle",
-    "UserPromptSubmit": "working",
-    "PostToolUse": "working",
-    "Notification": "blocked",
-    "SessionEnd": "clear"
-}'
-CODEX_EVENTS='{
-    "SessionStart": "idle",
-    "Stop": "idle",
-    "UserPromptSubmit": "working",
-    "PostToolUse": "working",
-    "PermissionRequest": "blocked"
-}'
+# Managed command substrings. A hook is treated as managed by this script
+# (and stripped before re-registration) when its command contains any marker.
+# Path-qualified where possible so Claude's own guard-* hooks are not touched.
+CLAUDE_MARKERS='[
+    "agent-status.sh",
+    ".agents/hooks/notify-sound.sh",
+    ".claude/hooks/notify-sound.sh"
+]'
+CODEX_MARKERS='[
+    "agent-status.sh",
+    ".agents/hooks/notify-sound.sh",
+    ".codex/hooks/guard-protected-apply-patch.sh",
+    ".codex/hooks/guard-force-push.sh"
+]'
 
-# Build {event: full_command} from {event: state}. The script path is wrapped
-# in single quotes so the command remains a valid shell command in the hook.
-build_commands() {
-    echo "$1" | jq --arg script "$SCRIPT" '
-        ([39] | implode) as $q
-        | to_entries
-        | map({key: .key, value: ("sh " + $q + $script + $q + " " + .value)})
-        | from_entries
+build_claude() {
+    jq -n '
+        def cmd($c): { type: "command", command: $c, timeout: 5 };
+        {
+            SessionStart:     [{ hooks: [cmd("sh ~/.tmux/agent-status.sh idle")] }],
+            Stop:             [{ hooks: [cmd("sh ~/.tmux/agent-status.sh idle")] }],
+            UserPromptSubmit: [{ hooks: [cmd("sh ~/.tmux/agent-status.sh working")] }],
+            PostToolUse:      [{ hooks: [cmd("sh ~/.tmux/agent-status.sh working")] }],
+            Notification:     [{ hooks: [
+                cmd("sh ~/.tmux/agent-status.sh blocked"),
+                cmd("sh ~/.agents/hooks/notify-sound.sh")
+            ]}],
+            SessionEnd:       [{ hooks: [cmd("sh ~/.tmux/agent-status.sh clear")] }]
+        }
     '
 }
 
+build_codex() {
+    jq -n '
+        def cmd($c): { type: "command", command: $c, timeout: 5 };
+        {
+            SessionStart:     [{ hooks: [cmd("sh ~/.tmux/agent-status.sh idle")] }],
+            Stop:             [{ hooks: [cmd("sh ~/.tmux/agent-status.sh idle")] }],
+            UserPromptSubmit: [{ hooks: [cmd("sh ~/.tmux/agent-status.sh working")] }],
+            PostToolUse:      [{ hooks: [cmd("sh ~/.tmux/agent-status.sh working")] }],
+            PermissionRequest:[{ hooks: [
+                cmd("sh ~/.tmux/agent-status.sh blocked"),
+                cmd("sh ~/.agents/hooks/notify-sound.sh")
+            ]}],
+            PreToolUse: [
+                { matcher: "^apply_patch$", hooks: [cmd("sh ~/.codex/hooks/guard-protected-apply-patch.sh")] },
+                { matcher: "^Bash$",        hooks: [cmd("sh ~/.codex/hooks/guard-force-push.sh")] }
+            ]
+        }
+    '
+}
+
+# jq expression that strips managed handlers, then optionally merges in the
+# desired shape. Empty matcher groups and empty events are pruned so the file
+# does not accumulate skeletons after uninstall.
+# shellcheck disable=SC2016  # jq プログラム本体。シェル展開させない。
+STRIP='
+    .hooks //= {}
+    | .hooks |= (
+        with_entries(
+            .value |= (
+                map(.hooks |= map(
+                    select(
+                        . as $h
+                        | ($markers | map(. as $m | ($h.command // "") | contains($m)) | any) | not
+                    )
+                ))
+                | map(select(.hooks | length > 0))
+            )
+        )
+        | with_entries(select(.value | length > 0))
+    )
+'
+
+# shellcheck disable=SC2016  # jq プログラム本体。シェル展開させない。
+MERGE='
+    reduce ($desired | to_entries[]) as $e (.;
+        .hooks[$e.key] = ((.hooks[$e.key] // []) + $e.value)
+    )
+'
+
 update() {
     path="$1"
-    commands="$2"
+    markers="$2"
+    desired="$3"  # empty when MODE=uninstall
+
     mkdir -p "$(dirname "$path")"
     [ -f "$path" ] || echo '{}' > "$path"
 
     tmp=$(mktemp)
     if [ "$MODE" = "install" ]; then
-        jq --argjson cmds "$commands" '
-            .hooks //= {}
-            | .hooks |= (
-                to_entries
-                | map(.value |= (
-                    map(.hooks |= map(select(.command | contains("agent-status.sh") | not)))
-                    | map(select(.hooks | length > 0))
-                ))
-                | map(select(.value | length > 0))
-                | from_entries
-            )
-            | reduce ($cmds | to_entries[]) as $e (.;
-                .hooks[$e.key] += [{
-                    hooks: [{type: "command", command: $e.value, timeout: 5}]
-                }]
-            )
-        ' "$path" > "$tmp"
+        jq --argjson markers "$markers" --argjson desired "$desired" \
+            "$STRIP | $MERGE" "$path" > "$tmp"
     else
-        jq '
-            .hooks //= {}
-            | .hooks |= (
-                to_entries
-                | map(.value |= (
-                    map(.hooks |= map(select(.command | contains("agent-status.sh") | not)))
-                    | map(select(.hooks | length > 0))
-                ))
-                | map(select(.value | length > 0))
-                | from_entries
-            )
-        ' "$path" > "$tmp"
+        jq --argjson markers "$markers" "$STRIP" "$path" > "$tmp"
     fi
     mv "$tmp" "$path"
     echo "$path: $MODE done"
 }
 
-update "$HOME/.claude/settings.json" "$(build_commands "$CLAUDE_EVENTS")"
-update "$HOME/.codex/hooks.json" "$(build_commands "$CODEX_EVENTS")"
-
 if [ "$MODE" = "install" ]; then
+    update "$HOME/.claude/settings.json" "$CLAUDE_MARKERS" "$(build_claude)"
+    update "$HOME/.codex/hooks.json"     "$CODEX_MARKERS"  "$(build_codex)"
+
     cat >&2 <<'MSG'
 
 Note: Codex will not run the new hooks until you trust them.
       Run 'codex' and execute '/hooks' to review and trust the entries.
 MSG
+else
+    update "$HOME/.claude/settings.json" "$CLAUDE_MARKERS" ""
+    update "$HOME/.codex/hooks.json"     "$CODEX_MARKERS"  ""
 fi

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -57,6 +57,13 @@ do
   if [[ $MODE == "link" ]]; then
     if [ -L $DEST ]; then
       echo "exist: $DEST"
+    elif [ -e $DEST ]; then
+      # 実ファイル / 実ディレクトリが既にある場合、そのまま `ln -s` すると
+      # `$DEST/<basename>` が作られてリンク構造が壊れる（例: 実ディレクトリの
+      # `~/.codex/hooks` 内に `hooks` symlink が生まれ、agent_hooks.sh の
+      # `-e` チェックが通らなくなる）。事故防止のため明示的に fail する。
+      echo "error: $DEST exists as a real file/directory. Move or delete it before running link." >&2
+      exit 1
     else
       DEST_PARENT=$(dirname "$DEST")
       [ -d "$DEST_PARENT" ] || mkdir -p "$DEST_PARENT"

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -41,6 +41,8 @@ TARGETS=( \
          ".markdownlint.yml" \
          ".claude/hooks" \
          ".claude/statusline.sh" \
+         ".codex/hooks" \
+         ".agents/hooks" \
        )
 
 for TARGET in ${TARGETS[@]}
@@ -56,6 +58,8 @@ do
     if [ -L $DEST ]; then
       echo "exist: $DEST"
     else
+      DEST_PARENT=$(dirname "$DEST")
+      [ -d "$DEST_PARENT" ] || mkdir -p "$DEST_PARENT"
       echo "link: $DEST"
       ln -s $SOURCE $DEST
     fi

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -1,0 +1,289 @@
+#!/bin/sh
+# ============================================================================
+# test-codex-hooks.sh
+#
+# 回帰テスト:
+#   1. Codex 用ガード (guard-protected-apply-patch.sh / guard-force-push.sh)
+#      - 保護対象 / 非保護対象、拒否パターン / 許可パターンの判定
+#      - 拒否時は hookSpecificOutput.permissionDecision == "deny" を返す
+#      - いずれの経路も終了コードは 0
+#   2. bin/agent_hooks.sh
+#      - 一時 HOME 上での install → reinstall → uninstall の冪等性
+#      - unrelated Hook の保持
+#      - 生成 JSON が jq empty を通る
+#   3. bin/link.sh
+#      - クリーンな HOME にディレクトリを含む TARGETS を link できる
+#      - unlink で symlink のみ削除される
+#
+# 依存: sh (POSIX), jq
+# 実行: sh bin/tests/test-codex-hooks.sh
+# ============================================================================
+
+set -eu
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+GUARD_APPLY="$REPO_ROOT/.codex/hooks/guard-protected-apply-patch.sh"
+GUARD_BASH="$REPO_ROOT/.codex/hooks/guard-force-push.sh"
+AGENT_HOOKS="$REPO_ROOT/bin/agent_hooks.sh"
+LINK_SH="$REPO_ROOT/bin/link.sh"
+
+WORK=$(mktemp -d)
+trap 'rm -rf "$WORK"' EXIT
+
+pass_count=0
+fail_count=0
+current_case=""
+
+pass() {
+    pass_count=$((pass_count + 1))
+    printf '  ok  %s\n' "$current_case"
+}
+
+fail() {
+    fail_count=$((fail_count + 1))
+    printf '  NG  %s: %s\n' "$current_case" "$1" >&2
+}
+
+# assert_deny: JSON input -> exit code 0 and permissionDecision == "deny".
+assert_deny() {
+    guard="$1"
+    input="$2"
+    out=$(printf '%s' "$input" | sh "$guard") || {
+        fail "guard exited non-zero"
+        return
+    }
+    decision=$(printf '%s' "$out" | jq -r '.hookSpecificOutput.permissionDecision // ""' 2>/dev/null || echo "")
+    if [ "$decision" != "deny" ]; then
+        fail "expected deny, got '$decision' from output: $out"
+        return
+    fi
+    pass
+}
+
+# assert_allow: JSON input -> exit code 0 and empty stdout.
+assert_allow() {
+    guard="$1"
+    input="$2"
+    out=$(printf '%s' "$input" | sh "$guard") || {
+        fail "guard exited non-zero"
+        return
+    }
+    if [ -n "$out" ]; then
+        fail "expected empty stdout, got: $out"
+        return
+    fi
+    pass
+}
+
+# ------------------------------------------------------------------
+# 1. guard-protected-apply-patch.sh
+# ------------------------------------------------------------------
+echo "# guard-protected-apply-patch"
+
+current_case="deny: Add File .env"
+assert_deny "$GUARD_APPLY" '{"tool_input":{"command":"*** Begin Patch\n*** Add File: .env\n+SECRET=1\n*** End Patch\n"}}'
+
+current_case="deny: Update File package-lock.json"
+assert_deny "$GUARD_APPLY" '{"tool_input":{"command":"*** Update File: package-lock.json\n@@ ...\n"}}'
+
+current_case="deny: Delete File yarn.lock"
+assert_deny "$GUARD_APPLY" '{"tool_input":{"command":"*** Delete File: yarn.lock\n"}}'
+
+current_case="deny: Move to Cargo.lock"
+assert_deny "$GUARD_APPLY" '{"tool_input":{"command":"*** Update File: old.lock\n*** Move to: Cargo.lock\n"}}'
+
+current_case="deny: Add File under .git/"
+assert_deny "$GUARD_APPLY" '{"tool_input":{"command":"*** Add File: .git/hooks/pre-commit\n"}}'
+
+current_case="deny: .env.local"
+assert_deny "$GUARD_APPLY" '{"tool_input":{"command":"*** Add File: apps/web/.env.local\n"}}'
+
+current_case="allow: normal source file"
+assert_allow "$GUARD_APPLY" '{"tool_input":{"command":"*** Update File: src/main.rs\n@@ -1 +1 @@\n"}}'
+
+current_case="allow: missing tool_input"
+assert_allow "$GUARD_APPLY" '{}'
+
+current_case="allow: no patch headers"
+assert_allow "$GUARD_APPLY" '{"tool_input":{"command":"echo hello"}}'
+
+# ------------------------------------------------------------------
+# 2. guard-force-push.sh
+# ------------------------------------------------------------------
+echo "# guard-force-push"
+
+current_case="deny: git push -f"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push -f origin main"}}'
+
+current_case="deny: git push --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --force origin main"}}'
+
+current_case="deny: git push --force=<val>"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --force=v1 origin main"}}'
+
+current_case="deny: git -c foo=bar push --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git -c foo=bar push --force origin main"}}'
+
+current_case="deny: raw force + with-lease併記"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease --force origin main"}}'
+
+current_case="deny: git push --mirror"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --mirror origin"}}'
+
+current_case="deny: +refspec"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push origin +main"}}'
+
+current_case="allow: git push --force-with-lease"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main"}}'
+
+current_case="allow: git push --force-with-lease --force-if-includes"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease --force-if-includes origin main"}}'
+
+current_case="allow: git push --force-if-includes only"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-if-includes origin main"}}'
+
+current_case="allow: git push (no force)"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push origin main"}}'
+
+current_case="allow: empty command"
+assert_allow "$GUARD_BASH" '{}'
+
+# ------------------------------------------------------------------
+# 3. agent_hooks.sh install / reinstall / uninstall
+# ------------------------------------------------------------------
+echo "# agent_hooks: install / reinstall / uninstall"
+
+HOME_DIR="$WORK/home"
+mkdir -p "$HOME_DIR/.tmux" "$HOME_DIR/.agents/hooks" "$HOME_DIR/.codex/hooks" "$HOME_DIR/.claude"
+touch "$HOME_DIR/.tmux/agent-status.sh"
+cp "$REPO_ROOT/.agents/hooks/notify-sound.sh" "$HOME_DIR/.agents/hooks/"
+cp "$GUARD_APPLY" "$HOME_DIR/.codex/hooks/"
+cp "$GUARD_BASH" "$HOME_DIR/.codex/hooks/"
+
+# Seed unrelated Claude hooks (guard-* から notify-sound legacy まで含める)
+cat > "$HOME_DIR/.claude/settings.json" <<'JSON'
+{
+  "hooks": {
+    "PreToolUse": [
+      { "matcher": "Edit|Write|MultiEdit", "hooks": [
+        { "type": "command", "command": "sh ~/.claude/hooks/guard-protected-files.sh", "timeout": 3 }
+      ]}
+    ],
+    "Notification": [
+      { "hooks": [
+        { "type": "command", "command": "sh ~/.claude/hooks/notify-sound.sh", "timeout": 3 },
+        { "type": "command", "command": "sh ~/.claude/hooks/user-unrelated.sh", "timeout": 3 }
+      ]}
+    ]
+  }
+}
+JSON
+
+HOME="$HOME_DIR" sh "$AGENT_HOOKS" install >/dev/null
+HOME="$HOME_DIR" sh "$AGENT_HOOKS" install >/dev/null
+
+current_case="claude Notification group count is 2 (unrelated + managed) after 2nd install"
+count=$(jq '.hooks.Notification | length' "$HOME_DIR/.claude/settings.json")
+if [ "$count" = "2" ]; then pass; else fail "expected 2, got $count"; fi
+
+current_case="claude PreToolUse unrelated guard is preserved"
+n=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command | contains("guard-protected-files.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="claude Notification user-unrelated is preserved"
+n=$(jq '[.hooks.Notification[]?.hooks[]? | select(.command | contains("user-unrelated.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="claude legacy .claude/hooks/notify-sound.sh is removed"
+n=$(jq '[.hooks.Notification[]?.hooks[]? | select(.command | contains(".claude/hooks/notify-sound.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "0" ]; then pass; else fail "expected 0, got $n"; fi
+
+current_case="claude shared notify-sound is registered once"
+n=$(jq '[.hooks.Notification[]?.hooks[]? | select(.command | contains(".agents/hooks/notify-sound.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="codex PreToolUse has exactly 2 matcher groups"
+n=$(jq '.hooks.PreToolUse | length' "$HOME_DIR/.codex/hooks.json")
+if [ "$n" = "2" ]; then pass; else fail "expected 2, got $n"; fi
+
+current_case="codex PermissionRequest group has 2 handlers"
+n=$(jq '.hooks.PermissionRequest[0].hooks | length' "$HOME_DIR/.codex/hooks.json")
+if [ "$n" = "2" ]; then pass; else fail "expected 2, got $n"; fi
+
+current_case="codex apply_patch matcher registered"
+n=$(jq '[.hooks.PreToolUse[]? | select(.matcher == "^apply_patch$")] | length' "$HOME_DIR/.codex/hooks.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="codex Bash matcher registered"
+n=$(jq '[.hooks.PreToolUse[]? | select(.matcher == "^Bash$")] | length' "$HOME_DIR/.codex/hooks.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="claude settings.json is valid JSON"
+if jq empty "$HOME_DIR/.claude/settings.json"; then pass; else fail "invalid JSON"; fi
+
+current_case="codex hooks.json is valid JSON"
+if jq empty "$HOME_DIR/.codex/hooks.json"; then pass; else fail "invalid JSON"; fi
+
+# Uninstall
+HOME="$HOME_DIR" sh "$AGENT_HOOKS" uninstall >/dev/null
+
+current_case="uninstall: claude unrelated guard is still preserved"
+n=$(jq '[.hooks.PreToolUse[]?.hooks[]? | select(.command | contains("guard-protected-files.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="uninstall: claude user-unrelated still preserved"
+n=$(jq '[.hooks.Notification[]?.hooks[]? | select(.command | contains("user-unrelated.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "1" ]; then pass; else fail "expected 1, got $n"; fi
+
+current_case="uninstall: claude tmux status handlers removed"
+n=$(jq '[.hooks | .. | objects | select(has("command")) | .command | select(contains("agent-status.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "0" ]; then pass; else fail "expected 0, got $n"; fi
+
+current_case="uninstall: claude shared notify-sound removed"
+n=$(jq '[.hooks | .. | objects | select(has("command")) | .command | select(contains(".agents/hooks/notify-sound.sh"))] | length' "$HOME_DIR/.claude/settings.json")
+if [ "$n" = "0" ]; then pass; else fail "expected 0, got $n"; fi
+
+current_case="uninstall: codex Codex-only guards removed"
+n=$(jq '[.hooks | .. | objects | select(has("command")) | .command | select(contains(".codex/hooks/guard-"))] | length' "$HOME_DIR/.codex/hooks.json")
+if [ "$n" = "0" ]; then pass; else fail "expected 0, got $n"; fi
+
+# ------------------------------------------------------------------
+# 4. link.sh
+# ------------------------------------------------------------------
+echo "# link.sh"
+
+LINK_HOME="$WORK/link_home"
+mkdir -p "$LINK_HOME"
+# link.sh uses HOME, pwd, and expects to be run from repo root. link mode takes no arg.
+(cd "$REPO_ROOT" && HOME="$LINK_HOME" sh "$LINK_SH" >/dev/null)
+
+current_case="link: ~/.agents/hooks is a symlink"
+if [ -L "$LINK_HOME/.agents/hooks" ]; then pass; else fail "not a symlink"; fi
+
+current_case="link: ~/.codex/hooks is a symlink"
+if [ -L "$LINK_HOME/.codex/hooks" ]; then pass; else fail "not a symlink"; fi
+
+current_case="link: ~/.claude/hooks is a symlink"
+if [ -L "$LINK_HOME/.claude/hooks" ]; then pass; else fail "not a symlink"; fi
+
+(cd "$REPO_ROOT" && HOME="$LINK_HOME" sh "$LINK_SH" unlink >/dev/null)
+
+current_case="unlink: ~/.agents/hooks symlink is removed"
+if [ ! -L "$LINK_HOME/.agents/hooks" ]; then pass; else fail "still a symlink"; fi
+
+current_case="unlink: ~/.codex/hooks symlink is removed"
+if [ ! -L "$LINK_HOME/.codex/hooks" ]; then pass; else fail "still a symlink"; fi
+
+# ------------------------------------------------------------------
+# 集計
+# ------------------------------------------------------------------
+echo ""
+echo "=========================================="
+printf '  passed: %d\n' "$pass_count"
+printf '  failed: %d\n' "$fail_count"
+echo "=========================================="
+
+if [ "$fail_count" -gt 0 ]; then
+    exit 1
+fi
+exit 0

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -190,11 +190,26 @@ assert_deny "$GUARD_BASH" '{"tool_input":{"command":"if true; then git push -f o
 current_case="deny: { ... ; } 内の force push"
 assert_deny "$GUARD_BASH" '{"tool_input":{"command":"{ git push --force origin main; }"}}'
 
+current_case="deny: command wrapper 経由の git push --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"command git push --force origin main"}}'
+
+current_case="deny: exec wrapper 経由の git push -f"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"exec git push -f origin main"}}'
+
+current_case="deny: 絶対パス git 経由の force push"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"/usr/bin/git push --force origin main"}}'
+
 current_case="allow: git checkout push --force (別 subcommand の arg が push)"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git checkout push --force"}}'
 
 current_case="allow: git --no-pager checkout push --force"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git --no-pager checkout push --force"}}'
+
+current_case="allow: git push -ofoo (push-option の値埋め込み、-f 結合形ではない)"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push -ofoo origin main"}}'
+
+current_case="allow: git push -o key=value origin main"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push -o key=value origin main"}}'
 
 current_case="allow: git push --force-with-lease"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main"}}'

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -175,6 +175,21 @@ assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push origin main \\\n  
 current_case="deny: quote 込み空白の env var 後の force push"
 assert_deny "$GUARD_BASH" "{\"tool_input\":{\"command\":\"GIT_SSH_COMMAND='ssh -i key' git push --force origin main\"}}"
 
+current_case="deny: --git-dir DIR global option 後の --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git --git-dir /tmp/repo/.git push --force origin main"}}'
+
+current_case="deny: --work-tree DIR global option 後の -f"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git --work-tree /tmp/tree push -f origin main"}}'
+
+current_case="deny: subshell 内の force push"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"(git push --force origin main)"}}'
+
+current_case="deny: if...then 内の force push"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"if true; then git push -f origin main; fi"}}'
+
+current_case="deny: { ... ; } 内の force push"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"{ git push --force origin main; }"}}'
+
 current_case="allow: git checkout push --force (別 subcommand の arg が push)"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git checkout push --force"}}'
 

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -145,6 +145,24 @@ assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push origin +main; echo
 current_case="deny: 複数コマンドの後段に危険な push"
 assert_deny "$GUARD_BASH" '{"tool_input":{"command":"echo start && git push --force origin main"}}'
 
+current_case="deny: 改行区切りの後段に危険な push"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"echo ok\ngit push --force origin main"}}'
+
+current_case="deny: 環境変数付き git push --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"GIT_SSH_COMMAND=ssh git push --force origin main"}}'
+
+current_case="deny: env コマンド経由の git push -f"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"env git push -f origin main"}}'
+
+current_case="deny: env + 環境変数付き git push --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"env FOO=bar git push --force origin main"}}'
+
+current_case="deny: 引用符付き --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push \"--force\" origin main"}}'
+
+current_case="deny: シングル引用符付き +refspec"
+assert_deny "$GUARD_BASH" "{\"tool_input\":{\"command\":\"git push origin '+main'\"}}"
+
 current_case="allow: git push --force-with-lease"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main"}}'
 

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -169,6 +169,18 @@ assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --force origin pus
 current_case="deny: refspec 名が push で -f"
 assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push -f origin push"}}'
 
+current_case="deny: 行継続の後段に --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push origin main \\\n  --force"}}'
+
+current_case="deny: quote 込み空白の env var 後の force push"
+assert_deny "$GUARD_BASH" "{\"tool_input\":{\"command\":\"GIT_SSH_COMMAND='ssh -i key' git push --force origin main\"}}"
+
+current_case="allow: git checkout push --force (別 subcommand の arg が push)"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git checkout push --force"}}'
+
+current_case="allow: git --no-pager checkout push --force"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git --no-pager checkout push --force"}}'
+
 current_case="allow: git push --force-with-lease"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main"}}'
 
@@ -321,6 +333,19 @@ if [ ! -L "$LINK_HOME/.agents/hooks" ]; then pass; else fail "still a symlink"; 
 
 current_case="unlink: ~/.codex/hooks symlink is removed"
 if [ ! -L "$LINK_HOME/.codex/hooks" ]; then pass; else fail "still a symlink"; fi
+
+# 既存の実ディレクトリがある場合 link.sh は fail-fast する
+LINK_HOME_CONFLICT="$WORK/link_home_conflict"
+mkdir -p "$LINK_HOME_CONFLICT/.codex/hooks"
+current_case="link: 実ディレクトリが既にあると明示的に fail"
+if (cd "$REPO_ROOT" && HOME="$LINK_HOME_CONFLICT" sh "$LINK_SH" >/dev/null 2>&1); then
+    fail "expected non-zero exit"
+else
+    pass
+fi
+
+current_case="link: fail 後は既存ディレクトリ配下にネストした symlink を作らない"
+if [ ! -L "$LINK_HOME_CONFLICT/.codex/hooks/hooks" ]; then pass; else fail "nested symlink created"; fi
 
 # ------------------------------------------------------------------
 # 集計

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -163,6 +163,12 @@ assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push \"--force\" origin
 current_case="deny: シングル引用符付き +refspec"
 assert_deny "$GUARD_BASH" "{\"tool_input\":{\"command\":\"git push origin '+main'\"}}"
 
+current_case="deny: refspec 名が push で --force"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --force origin push"}}'
+
+current_case="deny: refspec 名が push で -f"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push -f origin push"}}'
+
 current_case="allow: git push --force-with-lease"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main"}}'
 
@@ -180,6 +186,12 @@ assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-leas
 
 current_case="allow: git push -u (upstream, no force)"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push -u origin main"}}'
+
+current_case="allow: シングルクォート内の separator は分割しない (echo doc)"
+assert_allow "$GUARD_BASH" "{\"tool_input\":{\"command\":\"echo 'x;git push --force origin main'\"}}"
+
+current_case="allow: シングルクォート内の force 記述文字列"
+assert_allow "$GUARD_BASH" "{\"tool_input\":{\"command\":\"echo 'do not run git push --force'\"}}"
 
 current_case="allow: empty command"
 assert_allow "$GUARD_BASH" '{}'

--- a/bin/tests/test-codex-hooks.sh
+++ b/bin/tests/test-codex-hooks.sh
@@ -133,6 +133,18 @@ assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push --mirror origin"}}
 current_case="deny: +refspec"
 assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push origin +main"}}'
 
+current_case="deny: 短縮結合オプション -uf"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push -uf origin main"}}'
+
+current_case="deny: 短縮結合オプション -fu"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push -fu origin main"}}'
+
+current_case="deny: 複数コマンドの先頭が危険な +refspec"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"git push origin +main; echo push done"}}'
+
+current_case="deny: 複数コマンドの後段に危険な push"
+assert_deny "$GUARD_BASH" '{"tool_input":{"command":"echo start && git push --force origin main"}}'
+
 current_case="allow: git push --force-with-lease"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main"}}'
 
@@ -144,6 +156,12 @@ assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-if-includ
 
 current_case="allow: git push (no force)"
 assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push origin main"}}'
+
+current_case="allow: 安全な push の後段に --force を含む別コマンド"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push --force-with-lease origin main; echo --force done"}}'
+
+current_case="allow: git push -u (upstream, no force)"
+assert_allow "$GUARD_BASH" '{"tool_input":{"command":"git push -u origin main"}}'
 
 current_case="allow: empty command"
 assert_allow "$GUARD_BASH" '{}'


### PR DESCRIPTION
## Summary

Claude Code 用の安全ガード・注意喚起音を Codex Hooks の入出力仕様に合わせて移植する。既存の Claude Code ガード動作には手を入れず、共通化できる通知音のみ両 CLI で共用する。

Closes #195

## Key Changes

- **共有通知**: `.claude/hooks/notify-sound.sh` を `.agents/hooks/notify-sound.sh` に移設し、Claude Code の Notification / Codex の PermissionRequest 双方から呼ぶ
- **Codex 専用ガード**:
    - `.codex/hooks/guard-protected-apply-patch.sh`: apply_patch のパッチヘッダー (`*** Add/Update/Delete File`, `*** Move to`) から対象パスを抽出し、`.env` / `.env.*` / lockfile 各種 / `.git/` への変更を拒否
    - `.codex/hooks/guard-force-push.sh`: `.tool_input.command` を `;` / `&&` / `||` / `|` でサブコマンド分割し、各 `git ... push` の引数列に限定して `-f` / `--force` / 短縮結合形 (`-uf` 等) / `--mirror` / `+<refspec>` を拒否。`--force-with-lease` / `--force-if-includes` は許可
    - 拒否時は Codex 契約に沿って `hookSpecificOutput.permissionDecision=deny` を返し、終了コードは常に 0
- **登録の一元化**: `bin/agent_hooks.sh` に tmux status に加えて Codex ガード・共有通知の冪等な install / uninstall を統合。管理対象は command 文字列の部分一致で識別し、Claude 側の既存 guard-* / unrelated hooks は install / uninstall で影響を受けない
- **link**: `bin/link.sh` の TARGETS に `.codex/hooks` / `.agents/hooks` を追加、リンク先の親ディレクトリ (`~/.codex` 等) を `mkdir -p` で補完
- **テスト**: `bin/tests/test-codex-hooks.sh` を新設 (POSIX sh + jq)。ガード 26 ケース + install / reinstall / uninstall / link の 22 ケース、計 48 ケース

## Impact

- 導入後は Codex 側で `/hooks` から新規 Hook 定義を trust する必要がある (install 完了時に案内メッセージ表示)
- `~/.claude/settings.json` の Notification hook が `~/.claude/hooks/notify-sound.sh` から `~/.agents/hooks/notify-sound.sh` に自動的に付け替わる (`agent_hooks.sh` の markers で legacy path も除去対象)
- Claude Code の `PreToolUse` ガード (`.claude/hooks/guard-*.sh`) は本 PR の管理対象外なので既存動作のまま

## Test plan

- [x] `sh bin/tests/test-codex-hooks.sh` (48 ケース全 pass)
- [x] `sh -n` と `shellcheck` を新規 / 変更スクリプトに実行
- [x] 実 HOME で `make link && make agent_hooks` を実行し、Claude 既存 guard-* / statusline は維持、Codex hooks は新規登録されることを確認
- [x] 実際に `.env` への apply_patch / `git push --force` を stdin に渡し deny 応答を確認

## クロスレビュー

- cross-review `with-codex` で 1 iteration 実施。Codex が指摘した以下 2 件の force push bypass を修正済み:
    - `-uf` / `-fu` のような短縮結合オプションで raw force を検出できず通していた
    - 貪欲な `.*` regex により複数コマンド入力で最初の `+refspec` / 危険な push を検査できなかった
