### PR TITLE
feat: tmux エージェント状態インジケータの視認性を改善

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -73,8 +73,8 @@ set -g window-status-style fg=colour245,bg=black
 setw -g window-status-current-style fg=green,bg=black
 
 # AI agent status indicators (per-pane, written by ~/.tmux/agent-status.sh)
-setw -g window-status-format ' #I:#W#{?window_flags,#{window_flags},}#{?#{P:#{@agent_status}}, #{P:#{@agent_status}},} '
-setw -g window-status-current-format ' #I:#W#{?window_flags,#{window_flags},}#{?#{P:#{@agent_status}}, #{P:#{@agent_status}},} '
+setw -g window-status-format ' #{?#{P:#{@agent_status}},#{P:#{@agent_status}},}#I:#W#{?window_flags,#{window_flags},} '
+setw -g window-status-current-format ' #{?#{P:#{@agent_status}},#{P:#{@agent_status}},}#I:#W#{?window_flags,#{window_flags},} '
 
 # resize pane
 bind -r H resize-pane -L 5

--- a/.tmux/agent-status.sh
+++ b/.tmux/agent-status.sh
@@ -22,7 +22,7 @@ case "${1:-}" in
         color="colour160"
         ;;
     idle)
-        color="colour34"
+        color="colour244"
         ;;
     clear)
         tmux set-option -p -t "$TMUX_PANE" -u @agent_status 2>/dev/null || true
@@ -34,4 +34,4 @@ case "${1:-}" in
         ;;
 esac
 
-tmux set-option -p -t "$TMUX_PANE" @agent_status "#[fg=${color}]●#[default]" 2>/dev/null || true
+tmux set-option -p -t "$TMUX_PANE" @agent_status "#[fg=${color}]▌#[default]" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- idle 色を緑 (colour34) からグレー (colour244) に変更し、「手が空いている」ことがより直感的に伝わるようにする
- インジケータのマークを `●` (U+25CF) から `▌` (U+258C, LEFT HALF BLOCK) に変更してサイズを抑制
- インジケータをウィンドウ名の**前**に移動し、間のスペースも削除して視線移動を最小化

## Color mapping
| 色 | 状態 | 意味 |
|----|------|------|
| 青 (colour33) | working | エージェント作業中 |
| 赤 (colour160) | blocked | ユーザー操作待ち |
| グレー (colour244) | idle | 手が空いている |

## Test plan
- [ ] `tmux source-file ~/.tmux.conf` で反映後、Claude Code / Codex を起動して各状態の色・マーク・位置を確認
- [ ] `sh -n .tmux/agent-status.sh` の文法チェックが通ることを確認
- [ ] main エージェントが subagent を起動している間、青（working）が維持されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)