### PR TITLE
fix: notify-sound の音量を下げる

### DIFF
--- a/.agents/hooks/notify-sound.sh
+++ b/.agents/hooks/notify-sound.sh
@@ -29,6 +29,6 @@ command -v afplay >/dev/null 2>&1 || exit 0
 SOUND="/System/Library/Sounds/Ping.aiff"
 [ -f "$SOUND" ] || exit 0
 
-afplay "$SOUND" >/dev/null 2>&1 &
+afplay -v 0.05 "$SOUND" >/dev/null 2>&1 &
 
 exit 0


### PR DESCRIPTION
## Summary
- `.agents/hooks/notify-sound.sh` の `afplay` 呼び出しに `-v 0.05` を渡し、通知音の音量を絞る
- システム音量そのままだと通知音が大きすぎるため

## Test plan
- [ ] `.agents/hooks/notify-sound.sh` を手動実行し、想定どおり小さめの音量で Ping.aiff が鳴ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)