### PR TITLE
feat: Hammerspoon で OBS/screencapture 用の録画ガイドを追加

### DIFF
--- a/.hammerspoon/init.lua
+++ b/.hammerspoon/init.lua
@@ -153,3 +153,6 @@ local frontApp = hs.application.frontmostApplication()
 if frontApp and ctrlJTargetApps[frontApp:name()] then
 	ctrlJHotkey:enable()
 end
+
+-- OBS 録画用 1920x1080 ガイドオーバーレイ
+require("recording_guide")

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -235,10 +235,16 @@ function M.startRecording()
 	if state.canvas and state.visible then state.canvas:hide() end
 	state.recordingTask = hs.task.new(
 		"/usr/sbin/screencapture",
-		function(_exitCode, _stdout, _stderr)
+		function(exitCode, _stdout, _stderr)
 			state.recordingTask = nil
 			if state.visible and state.canvas then
 				state.canvas:show()
+			end
+			-- 録画プロセスが実際に終了 → ファイル確定後に Finder で表示
+			local finishedPath = state.recordingPath
+			state.recordingPath = nil
+			if finishedPath and exitCode == 0 and hs.fs.attributes(finishedPath) then
+				hs.execute(string.format("open -R %q", finishedPath))
 			end
 			updateMenubarTitle()
 		end,
@@ -256,15 +262,7 @@ function M.stopRecording()
 	if pid then
 		hs.execute("kill -INT " .. pid)
 	end
-	local path = state.recordingPath
-	state.recordingPath = nil
-	-- canvas 復元は task 完了 callback で行う (プロセス終了完了後)
-	-- ファイル確定を待って Finder で表示
-	if path then
-		hs.timer.doAfter(1.2, function()
-			hs.execute(string.format("open -R %q", path))
-		end)
-	end
+	-- canvas 復元 / Finder 表示は task 完了 callback で行う (プロセス終了完了後)
 end
 
 function M.toggleRecording()

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -1,0 +1,254 @@
+-- OBS 録画用 1920x1080 ガイドオーバーレイ
+-- 4K ディスプレイ全体をキャプチャし、本モジュールが示す領域だけをクロップして録画する用途
+
+local M = {}
+
+-- hs.reload() 時の二重登録防止: 既存インスタンスをクリーンアップ
+if _G.__recording_guide_state then
+	local prev = _G.__recording_guide_state
+	if prev.canvas then prev.canvas:delete() end
+	if prev.menubar then prev.menubar:delete() end
+end
+
+local SETTINGS_PREFIX = "recording_guide."
+local DEFAULTS = {
+	outputWidth = 1920,
+	outputHeight = 1080,
+	dimOpacity = 0.2,
+	borderWidth = 3,
+	dimOutside = true,
+}
+
+local state = {
+	canvas = nil,
+	menubar = nil,
+	visible = false,
+	dimOutside = DEFAULTS.dimOutside,
+}
+_G.__recording_guide_state = state
+-- 過去バージョンで永続化された dimOutside を破棄し、常に default から始める
+hs.settings.clear(SETTINGS_PREFIX .. "dimOutside")
+
+local function getSetting(key)
+	local v = hs.settings.get(SETTINGS_PREFIX .. key)
+	if v == nil then return DEFAULTS[key] end
+	return v
+end
+
+local function setSetting(key, value)
+	hs.settings.set(SETTINGS_PREFIX .. key, value)
+end
+
+-- 対象ディスプレイを解決する。ユーザーが選んだ画面を優先し、
+-- なければ物理ピクセル数が最大のもの (通常は 4K 外部) を採用する。
+local function getTargetScreen()
+	local savedName = hs.settings.get(SETTINGS_PREFIX .. "targetScreenName")
+	local screens = hs.screen.allScreens()
+	if savedName then
+		for _, s in ipairs(screens) do
+			if s:name() == savedName then return s end
+		end
+	end
+	local best, bestPixels = nil, 0
+	for _, s in ipairs(screens) do
+		local mode = s:currentMode()
+		local p = (mode.w or 0) * (mode.h or 0)
+		if p > bestPixels then
+			bestPixels = p
+			best = s
+		end
+	end
+	return best or hs.screen.mainScreen()
+end
+
+-- fullFrame() を使う。OBS の Display Capture はメニューバー含む全画面を対象にするため
+local function computeGuide(screen)
+	local frame = screen:fullFrame()
+	local mode = screen:currentMode()
+	local scaleX = mode.w / frame.w
+	local scaleY = mode.h / frame.h
+	local outW = getSetting("outputWidth")
+	local outH = getSetting("outputHeight")
+	local guideWpt = outW / scaleX
+	local guideHpt = outH / scaleY
+	-- ディスプレイに収まらない場合はプレビュー用に 16:9 維持したまま縮小
+	local previewScale = 1
+	if guideWpt > frame.w or guideHpt > frame.h then
+		-- 16:9 のまま画面いっぱいまで拡大。border stroke は端で若干クリップされるが視認性優先
+		previewScale = math.min(frame.w / guideWpt, frame.h / guideHpt)
+		guideWpt = guideWpt * previewScale
+		guideHpt = guideHpt * previewScale
+	end
+	return {
+		screenFrame = frame,
+		modeW = mode.w,
+		modeH = mode.h,
+		scaleX = scaleX,
+		scaleY = scaleY,
+		previewScale = previewScale,
+		x = frame.x + (frame.w - guideWpt) / 2,
+		y = frame.y + (frame.h - guideHpt) / 2,
+		w = guideWpt,
+		h = guideHpt,
+	}
+end
+
+local function rebuildCanvas()
+	if state.canvas then
+		state.canvas:delete()
+		state.canvas = nil
+	end
+
+	local screen = getTargetScreen()
+	local g = computeGuide(screen)
+	local frame = g.screenFrame
+
+	local canvas = hs.canvas.new({ x = frame.x, y = frame.y, w = frame.w, h = frame.h })
+	canvas:level(hs.canvas.windowLevels.overlay)
+	canvas:behavior({
+		hs.canvas.windowBehaviors.canJoinAllSpaces,
+		hs.canvas.windowBehaviors.stationary,
+		hs.canvas.windowBehaviors.fullScreenAuxiliary,
+	})
+	-- 全マウスイベントを透過
+	canvas:canvasMouseEvents(false, false, false, false)
+
+	-- canvas 内座標系は左上原点 (frame ローカル)
+	local localX = g.x - frame.x
+	local localY = g.y - frame.y
+
+	-- 暗幕: 4 枠で録画領域外だけを塗る (compositeRule より単純で確実)
+	if state.dimOutside then
+		local dim = { red = 0, green = 0, blue = 0, alpha = getSetting("dimOpacity") }
+		-- Top
+		canvas[#canvas + 1] = {
+			type = "rectangle", action = "fill", fillColor = dim,
+			frame = { x = 0, y = 0, w = frame.w, h = localY },
+		}
+		-- Bottom
+		canvas[#canvas + 1] = {
+			type = "rectangle", action = "fill", fillColor = dim,
+			frame = { x = 0, y = localY + g.h, w = frame.w, h = frame.h - (localY + g.h) },
+		}
+		-- Left
+		canvas[#canvas + 1] = {
+			type = "rectangle", action = "fill", fillColor = dim,
+			frame = { x = 0, y = localY, w = localX, h = g.h },
+		}
+		-- Right
+		canvas[#canvas + 1] = {
+			type = "rectangle", action = "fill", fillColor = dim,
+			frame = { x = localX + g.w, y = localY, w = frame.w - (localX + g.w), h = g.h },
+		}
+	end
+
+	-- 境界線
+	canvas[#canvas + 1] = {
+		type = "rectangle",
+		action = "stroke",
+		strokeColor = { red = 1, green = 0.2, blue = 0.2, alpha = 1 },
+		strokeWidth = getSetting("borderWidth"),
+		frame = { x = localX, y = localY, w = g.w, h = g.h },
+	}
+
+	state.canvas = canvas
+	if state.visible then canvas:show() end
+end
+
+function M.show()
+	state.visible = true
+	if not state.canvas then rebuildCanvas() end
+	state.canvas:show()
+end
+
+function M.hide()
+	state.visible = false
+	if state.canvas then state.canvas:hide() end
+end
+
+function M.toggle()
+	if state.visible then M.hide() else M.show() end
+end
+
+function M.center()
+	rebuildCanvas()
+end
+
+function M.toggleDimming()
+	state.dimOutside = not state.dimOutside
+	rebuildCanvas()
+end
+
+function M.copyCrop()
+	local screen = getTargetScreen()
+	local g = computeGuide(screen)
+	if g.previewScale < 1 then
+		hs.alert.show("Preview mode: OBS crop values not accurate on this display")
+		return
+	end
+	local outW = getSetting("outputWidth")
+	local outH = getSetting("outputHeight")
+	local left = math.floor((g.x - g.screenFrame.x) * g.scaleX + 0.5)
+	local top = math.floor((g.y - g.screenFrame.y) * g.scaleY + 0.5)
+	local right = g.modeW - left - outW
+	local bottom = g.modeH - top - outH
+	local text = string.format(
+		"OBS Crop\nLeft: %d\nTop: %d\nRight: %d\nBottom: %d\nOutput: %dx%d",
+		left, top, right, bottom, outW, outH
+	)
+	hs.pasteboard.setContents(text)
+	hs.alert.show("Copied OBS crop values")
+end
+
+local function targetDisplaySubmenu()
+	local items = {}
+	local activeScreen = getTargetScreen()
+	local savedName = hs.settings.get(SETTINGS_PREFIX .. "targetScreenName")
+	for _, s in ipairs(hs.screen.allScreens()) do
+		local mode = s:currentMode()
+		local name = s:name() or "Unknown"
+		local screen = s
+		table.insert(items, {
+			title = string.format("%s (%dx%d)", name, mode.w or 0, mode.h or 0),
+			checked = screen:id() == activeScreen:id(),
+			fn = function()
+				hs.settings.set(SETTINGS_PREFIX .. "targetScreenName", screen:name())
+				rebuildCanvas()
+			end,
+		})
+	end
+	if savedName then
+		table.insert(items, { title = "-" })
+		table.insert(items, {
+			title = "Auto (Largest Display)",
+			fn = function()
+				hs.settings.set(SETTINGS_PREFIX .. "targetScreenName", nil)
+				rebuildCanvas()
+			end,
+		})
+	end
+	return items
+end
+
+local function buildMenubar()
+	local mb = hs.menubar.new()
+	if mb == nil then return nil end
+	mb:setTitle("REC")
+	mb:setTooltip("Recording Guide")
+	mb:setMenu(function()
+		return {
+			{ title = state.visible and "Hide Guide" or "Show Guide", fn = M.toggle },
+			{ title = "Center Guide", fn = M.center },
+			{ title = "-" },
+			{ title = "Toggle Outside Dimming", fn = M.toggleDimming, checked = state.dimOutside },
+			{ title = "Target Display", menu = targetDisplaySubmenu() },
+			{ title = "-" },
+			{ title = "Copy OBS Crop Values", fn = M.copyCrop },
+		}
+	end)
+	return mb
+end
+
+state.menubar = buildMenubar()
+
+return M

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -57,7 +57,9 @@ local function getTargetScreen()
 	local best, bestPixels = nil, 0
 	for _, s in ipairs(screens) do
 		local mode = s:currentMode()
-		local p = (mode.w or 0) * (mode.h or 0)
+		local scale = mode.scale or 1
+		-- 物理ピクセル数で比較する (mode.w/h はポイント)
+		local p = (mode.w or 0) * (mode.h or 0) * scale * scale
 		if p > bestPixels then
 			bestPixels = p
 			best = s
@@ -188,7 +190,8 @@ end
 function M.show()
 	state.visible = true
 	if not state.canvas then rebuildCanvas() end
-	state.canvas:show()
+	-- 録画中は canvas を表示しない (border/暗幕が録画に混入するため)
+	if not state.recordingTask then state.canvas:show() end
 	updateMenubarTitle()
 end
 
@@ -224,19 +227,17 @@ function M.startRecording()
 	local path = string.format("%s/Movies/recording-guide-%s.mov", os.getenv("HOME"), ts)
 	local rect = string.format("%.0f,%.0f,%.0f,%.0f", g.x, g.y, g.w, g.h)
 	state.recordingPath = path
-	-- ガイドの border が録画に混入するため一時的に非表示 (状態は wasVisibleBeforeRecording に保持)
-	state.wasVisibleBeforeRecording = state.visible
+	-- ガイドの border が録画に混入するため一時的に非表示。
+	-- 復元は task 完了 callback 内で「その時点の state.visible」を見て判定する
+	-- (録画中にユーザーが Hide/Show した最終状態を尊重する)。
 	if state.canvas and state.visible then state.canvas:hide() end
 	state.recordingTask = hs.task.new(
 		"/usr/sbin/screencapture",
 		function(_exitCode, _stdout, _stderr)
 			state.recordingTask = nil
-			-- screencapture プロセスが実際に終了したここで canvas を復元。
-			-- stopRecording 経由でも外部シグナル終了でも共通で復元される。
-			if state.wasVisibleBeforeRecording and state.canvas then
+			if state.visible and state.canvas then
 				state.canvas:show()
 			end
-			state.wasVisibleBeforeRecording = nil
 			updateMenubarTitle()
 		end,
 		{ "-v", "-g", "-R", rect, path }

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -6,8 +6,10 @@ local M = {}
 -- hs.reload() 時の二重登録防止: 既存インスタンスをクリーンアップ
 if _G.__recording_guide_state then
 	local prev = _G.__recording_guide_state
-	if prev.canvas then prev.canvas:delete() end
-	if prev.menubar then prev.menubar:delete() end
+	-- SIGINT 後に発火する task 完了 callback は prev への closure を持つため、
+	-- 破棄後の canvas/menubar を触らないよう先にフィールドを nil 化しておく
+	if prev.canvas then prev.canvas:delete(); prev.canvas = nil end
+	if prev.menubar then prev.menubar:delete(); prev.menubar = nil end
 	if prev.recordingTask and prev.recordingTask:isRunning() then
 		local pid = prev.recordingTask:pid()
 		if pid then hs.execute("kill -INT " .. pid) end

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -34,6 +34,8 @@ local state = {
 _G.__recording_guide_state = state
 -- 過去バージョンで永続化された dimOutside を破棄し、常に default から始める
 hs.settings.clear(SETTINGS_PREFIX .. "dimOutside")
+-- 旧 key (name ベース) は UUID ベースに移行済み。ゴミを掃除しておく
+hs.settings.clear(SETTINGS_PREFIX .. "targetScreenName")
 
 local function getSetting(key)
 	local v = hs.settings.get(SETTINGS_PREFIX .. key)
@@ -47,12 +49,13 @@ end
 
 -- 対象ディスプレイを解決する。ユーザーが選んだ画面を優先し、
 -- なければ物理ピクセル数が最大のもの (通常は 4K 外部) を採用する。
+-- 同型モニタ複数接続でも一意に識別できるよう UUID を保存 key に使う。
 local function getTargetScreen()
-	local savedName = hs.settings.get(SETTINGS_PREFIX .. "targetScreenName")
+	local savedUUID = hs.settings.get(SETTINGS_PREFIX .. "targetScreenUUID")
 	local screens = hs.screen.allScreens()
-	if savedName then
+	if savedUUID then
 		for _, s in ipairs(screens) do
-			if s:name() == savedName then return s end
+			if s:getUUID() == savedUUID then return s end
 		end
 	end
 	local best, bestPixels = nil, 0
@@ -71,8 +74,12 @@ end
 local function computeGuide(screen)
 	local frame = screen:fullFrame()
 	local mode = screen:currentMode()
-	local scaleX = mode.w / frame.w
-	local scaleY = mode.h / frame.h
+	-- currentMode().w/h は POINT のため、物理ピクセルには mode.scale を掛ける必要がある
+	local scaleFactor = mode.scale or 1
+	local modePxW = mode.w * scaleFactor
+	local modePxH = mode.h * scaleFactor
+	local scaleX = modePxW / frame.w
+	local scaleY = modePxH / frame.h
 	local outW = getSetting("outputWidth")
 	local outH = getSetting("outputHeight")
 	local guideWpt = outW / scaleX
@@ -87,8 +94,8 @@ local function computeGuide(screen)
 	end
 	return {
 		screenFrame = frame,
-		modeW = mode.w,
-		modeH = mode.h,
+		modeW = modePxW,
+		modeH = modePxH,
 		scaleX = scaleX,
 		scaleY = scaleY,
 		previewScale = previewScale,
@@ -209,7 +216,6 @@ end
 
 function M.startRecording()
 	if state.recordingTask then
-		hs.alert.show("Already recording")
 		return
 	end
 	local screen = getTargetScreen()
@@ -221,6 +227,9 @@ function M.startRecording()
 	local path = string.format("%s/Movies/recording-guide-%s.mov", os.getenv("HOME"), ts)
 	local rect = string.format("%.0f,%.0f,%.0f,%.0f", g.x, g.y, g.w, g.h)
 	state.recordingPath = path
+	-- ガイドの border が録画に混入するため一時的に非表示 (状態は wasVisibleBeforeRecording に保持)
+	state.wasVisibleBeforeRecording = state.visible
+	if state.canvas and state.visible then state.canvas:hide() end
 	state.recordingTask = hs.task.new(
 		"/usr/sbin/screencapture",
 		function(_exitCode, _stdout, _stderr)
@@ -230,13 +239,11 @@ function M.startRecording()
 		{ "-v", "-g", "-R", rect, path }
 	)
 	state.recordingTask:start()
-	hs.alert.show("Recording started\n" .. path:match("([^/]+)$"))
 	updateMenubarTitle()
 end
 
 function M.stopRecording()
 	if not state.recordingTask then
-		hs.alert.show("Not recording")
 		return
 	end
 	local pid = state.recordingTask:pid()
@@ -245,7 +252,11 @@ function M.stopRecording()
 	end
 	local path = state.recordingPath
 	state.recordingPath = nil
-	hs.alert.show("Recording stopped")
+	-- 録画開始時に隠していた canvas を復元
+	if state.wasVisibleBeforeRecording and state.canvas then
+		state.canvas:show()
+	end
+	state.wasVisibleBeforeRecording = nil
 	-- ファイル確定を待って Finder で表示
 	if path then
 		hs.timer.doAfter(1.2, function()
@@ -282,7 +293,7 @@ end
 local function targetDisplaySubmenu()
 	local items = {}
 	local activeScreen = getTargetScreen()
-	local savedName = hs.settings.get(SETTINGS_PREFIX .. "targetScreenName")
+	local savedUUID = hs.settings.get(SETTINGS_PREFIX .. "targetScreenUUID")
 	for _, s in ipairs(hs.screen.allScreens()) do
 		local mode = s:currentMode()
 		local name = s:name() or "Unknown"
@@ -291,17 +302,17 @@ local function targetDisplaySubmenu()
 			title = string.format("%s (%dx%d)", name, mode.w or 0, mode.h or 0),
 			checked = screen:id() == activeScreen:id(),
 			fn = function()
-				hs.settings.set(SETTINGS_PREFIX .. "targetScreenName", screen:name())
+				hs.settings.set(SETTINGS_PREFIX .. "targetScreenUUID", screen:getUUID())
 				rebuildCanvas()
 			end,
 		})
 	end
-	if savedName then
+	if savedUUID then
 		table.insert(items, { title = "-" })
 		table.insert(items, {
 			title = "Auto (Largest Display)",
 			fn = function()
-				hs.settings.set(SETTINGS_PREFIX .. "targetScreenName", nil)
+				hs.settings.set(SETTINGS_PREFIX .. "targetScreenUUID", nil)
 				rebuildCanvas()
 			end,
 		})

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -8,6 +8,10 @@ if _G.__recording_guide_state then
 	local prev = _G.__recording_guide_state
 	if prev.canvas then prev.canvas:delete() end
 	if prev.menubar then prev.menubar:delete() end
+	if prev.recordingTask and prev.recordingTask:isRunning() then
+		local pid = prev.recordingTask:pid()
+		if pid then hs.execute("kill -INT " .. pid) end
+	end
 end
 
 local SETTINGS_PREFIX = "recording_guide."
@@ -24,6 +28,8 @@ local state = {
 	menubar = nil,
 	visible = false,
 	dimOutside = DEFAULTS.dimOutside,
+	recordingTask = nil,
+	recordingPath = nil,
 }
 _G.__recording_guide_state = state
 -- 過去バージョンで永続化された dimOutside を破棄し、常に default から始める
@@ -157,11 +163,18 @@ end
 
 local function updateMenubarTitle()
 	if not state.menubar then return end
-	if state.visible then
+	local font = { name = ".AppleSystemUIFont", size = 13 }
+	if state.recordingTask then
+		state.menubar:setTitle(hs.styledtext.new(" ● REC ", {
+			color = { white = 1, alpha = 1 },
+			backgroundColor = { red = 0.85, green = 0.15, blue = 0.15, alpha = 1 },
+			font = font,
+		}))
+	elseif state.visible then
 		state.menubar:setTitle(hs.styledtext.new(" REC ", {
 			color = { white = 1, alpha = 1 },
 			backgroundColor = { white = 0.4, alpha = 1 },
-			font = { name = ".AppleSystemUIFont", size = 13 },
+			font = font,
 		}))
 	else
 		state.menubar:setTitle("REC")
@@ -192,6 +205,57 @@ end
 function M.toggleDimming()
 	state.dimOutside = not state.dimOutside
 	rebuildCanvas()
+end
+
+function M.startRecording()
+	if state.recordingTask then
+		hs.alert.show("Already recording")
+		return
+	end
+	local screen = getTargetScreen()
+	local g = computeGuide(screen)
+	if g.previewScale < 1 then
+		hs.alert.show("Preview mode: recording at scaled size, not 1920x1080")
+	end
+	local ts = os.date("%Y%m%d-%H%M%S")
+	local path = string.format("%s/Movies/recording-guide-%s.mov", os.getenv("HOME"), ts)
+	local rect = string.format("%.0f,%.0f,%.0f,%.0f", g.x, g.y, g.w, g.h)
+	state.recordingPath = path
+	state.recordingTask = hs.task.new(
+		"/usr/sbin/screencapture",
+		function(_exitCode, _stdout, _stderr)
+			state.recordingTask = nil
+			updateMenubarTitle()
+		end,
+		{ "-v", "-g", "-R", rect, path }
+	)
+	state.recordingTask:start()
+	hs.alert.show("Recording started\n" .. path:match("([^/]+)$"))
+	updateMenubarTitle()
+end
+
+function M.stopRecording()
+	if not state.recordingTask then
+		hs.alert.show("Not recording")
+		return
+	end
+	local pid = state.recordingTask:pid()
+	if pid then
+		hs.execute("kill -INT " .. pid)
+	end
+	local path = state.recordingPath
+	state.recordingPath = nil
+	hs.alert.show("Recording stopped")
+	-- ファイル確定を待って Finder で表示
+	if path then
+		hs.timer.doAfter(1.2, function()
+			hs.execute(string.format("open -R %q", path))
+		end)
+	end
+end
+
+function M.toggleRecording()
+	if state.recordingTask then M.stopRecording() else M.startRecording() end
 end
 
 function M.copyCrop()
@@ -252,6 +316,8 @@ local function buildMenubar()
 	mb:setTooltip("Recording Guide")
 	mb:setMenu(function()
 		return {
+			{ title = state.recordingTask and "Stop Recording" or "Start Recording (mic on)", fn = M.toggleRecording },
+			{ title = "-" },
 			{ title = state.visible and "Hide Guide" or "Show Guide", fn = M.toggle },
 			{ title = "Center Guide", fn = M.center },
 			{ title = "-" },

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -32,10 +32,6 @@ local state = {
 	recordingPath = nil,
 }
 _G.__recording_guide_state = state
--- 過去バージョンで永続化された dimOutside を破棄し、常に default から始める
-hs.settings.clear(SETTINGS_PREFIX .. "dimOutside")
--- 旧 key (name ベース) は UUID ベースに移行済み。ゴミを掃除しておく
-hs.settings.clear(SETTINGS_PREFIX .. "targetScreenName")
 
 local function getSetting(key)
 	local v = hs.settings.get(SETTINGS_PREFIX .. key)
@@ -165,7 +161,8 @@ local function rebuildCanvas()
 	}
 
 	state.canvas = canvas
-	if state.visible then canvas:show() end
+	-- 録画中はガイドを再表示しない (border/暗幕が録画に混入するため)
+	if state.visible and not state.recordingTask then canvas:show() end
 end
 
 local function updateMenubarTitle()
@@ -234,6 +231,12 @@ function M.startRecording()
 		"/usr/sbin/screencapture",
 		function(_exitCode, _stdout, _stderr)
 			state.recordingTask = nil
+			-- screencapture プロセスが実際に終了したここで canvas を復元。
+			-- stopRecording 経由でも外部シグナル終了でも共通で復元される。
+			if state.wasVisibleBeforeRecording and state.canvas then
+				state.canvas:show()
+			end
+			state.wasVisibleBeforeRecording = nil
 			updateMenubarTitle()
 		end,
 		{ "-v", "-g", "-R", rect, path }
@@ -252,11 +255,7 @@ function M.stopRecording()
 	end
 	local path = state.recordingPath
 	state.recordingPath = nil
-	-- 録画開始時に隠していた canvas を復元
-	if state.wasVisibleBeforeRecording and state.canvas then
-		state.canvas:show()
-	end
-	state.wasVisibleBeforeRecording = nil
+	-- canvas 復元は task 完了 callback で行う (プロセス終了完了後)
 	-- ファイル確定を待って Finder で表示
 	if path then
 		hs.timer.doAfter(1.2, function()

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -155,15 +155,30 @@ local function rebuildCanvas()
 	if state.visible then canvas:show() end
 end
 
+local function updateMenubarTitle()
+	if not state.menubar then return end
+	if state.visible then
+		state.menubar:setTitle(hs.styledtext.new(" REC ", {
+			color = { white = 1, alpha = 1 },
+			backgroundColor = { white = 0.4, alpha = 1 },
+			font = { name = ".AppleSystemUIFont", size = 13 },
+		}))
+	else
+		state.menubar:setTitle("REC")
+	end
+end
+
 function M.show()
 	state.visible = true
 	if not state.canvas then rebuildCanvas() end
 	state.canvas:show()
+	updateMenubarTitle()
 end
 
 function M.hide()
 	state.visible = false
 	if state.canvas then state.canvas:hide() end
+	updateMenubarTitle()
 end
 
 function M.toggle()

--- a/docs/plans/add-recording-guide.md
+++ b/docs/plans/add-recording-guide.md
@@ -112,11 +112,14 @@ Output: 1920x1080
 
 `hs.settings.set()` / `hs.settings.get()` を使い、以下を保存する:
 
-- `dimOutside` (bool, default true)
-- `dimOpacity` (float, default 0.55)
+- `dimOpacity` (float, default 0.2)
 - `borderWidth` (float, default 3)
 - `outputWidth` (int, default 1920)
 - `outputHeight` (int, default 1080)
+- `targetScreenUUID` (string, ユーザーが Target Display から手動選択した画面の UUID)
+
+`dimOutside` は **敢えて永続化しない**。ユーザー要望により常に default (true) から起動し、
+Toggle Outside Dimming はセッション内でのみ有効。`hs.reload()` すると ON に戻る。
 
 MVP では設定 UI は用意せず、値の変更は init.lua 内で定数を書き換える運用でよい。
 

--- a/docs/plans/add-recording-guide.md
+++ b/docs/plans/add-recording-guide.md
@@ -1,0 +1,246 @@
+# Recording Guide (Hammerspoon 版) 追加計画
+
+## ステータス: 未着手
+
+**予定ブランチ**: `feat/add-recording-guide`
+**由来**: `fillin/recording-guide-app` リポジトリの Swift 版 spec (`docs/specs/recording-guide-app.md`) を Hammerspoon に移植したもの。
+
+## 概要
+
+32 インチ 4K ディスプレイ上に、YouTube 録画用の 1920×1080 ピクセル相当の作業領域を常時表示する Hammerspoon モジュールを追加する。OBS では 4K ディスプレイ全体をキャプチャし、本モジュールが示す 1920×1080 領域だけをクロップして録画する。
+
+Swift + Xcode で新規アプリを立ち上げる代わりに、既存の Hammerspoon 設定 (`.hammerspoon/init.lua`) にモジュールを 1 本足すだけで実現する。
+
+## 背景
+
+### 元の要求（Swift 版 spec のサマリ）
+
+- 画面上に物理ピクセル換算で 1920×1080 の録画領域を表示
+- 録画領域外を半透明の黒で暗くする
+- 領域内はクリック透過（背面の VS Code / Terminal / ブラウザを通常操作可能）
+- 常時最前面
+- メニューバー常駐（Dock 非表示）
+- OBS クロップ値（Left/Top/Right/Bottom）をクリップボードにコピー
+- Retina スケーリング対応
+
+### なぜ Hammerspoon 版か
+
+- Swift/SwiftUI + AppKit で新規アプリを立ち上げるより、Hammerspoon の `hs.canvas` / `hs.menubar` / `hs.screen` を使う方が実装量・環境コストが桁違いに少ない
+- 既存の `~/.hammerspoon/init.lua` に既に IME 切替やアプリトグルが載っており、dotfiles で管理されている
+- Xcode / xcodebuild / コード署名まわりの手間がゼロ
+- 100〜150 行程度の Lua 1 ファイルで MVP が閉じる
+
+## 設定構造
+
+```
+.hammerspoon/
+├── init.lua              # 末尾に require("recording_guide") を追加
+└── recording_guide.lua   # 新規モジュール（本 spec の実装対象）
+```
+
+Spoon 化はしない。既存 `init.lua` と同じ「素の Lua モジュール + `require`」パターンに寄せる。
+
+## MVP 機能
+
+### 1. 録画領域の表示
+
+- 対象ディスプレイ全体を覆う `hs.canvas` を 1 枚生成
+- 中央に 1920×1080 相当の透明な抜き領域を描画
+- 抜き領域外は半透明の黒（デフォルト opacity 0.55）
+- 抜き領域の境界線を表示（デフォルト 3pt）
+
+### 2. クリック透過
+
+`hs.canvas` の `canvasMouseEvents` を全 false に設定し、背面アプリへマウスイベントを完全に透過させる。
+
+```lua
+canvas:canvasMouseEvents(false, false, false, false)
+```
+
+### 3. 常時最前面 + 全 Space 表示
+
+```lua
+canvas:level(hs.canvas.windowLevels.overlay)
+canvas:behavior({
+    hs.canvas.windowBehaviors.canJoinAllSpaces,
+    hs.canvas.windowBehaviors.stationary,
+    hs.canvas.windowBehaviors.fullScreenAuxiliary,
+})
+```
+
+### 4. メニューバー常駐
+
+`hs.menubar.new()` でアイコンを作成し、以下の項目を提供する:
+
+- Show Guide
+- Hide Guide
+- Center Guide
+- Toggle Outside Dimming
+- Copy OBS Crop Values
+- (Quit は Hammerspoon 自体の常駐なので不要)
+
+### 5. Retina 対応
+
+`hs.screen` から `frame`（ポイント）と物理解像度（`mode().w` / `mode().h`）を取得し、両者の比率でスケール係数を求める。録画領域は物理ピクセルで 1920×1080 になるようポイント換算する。
+
+```lua
+local screen = hs.screen.mainScreen()
+local frame  = screen:frame()          -- ポイント単位
+local mode   = screen:currentMode()    -- mode.w / mode.h が物理ピクセル
+local scaleX = mode.w / frame.w
+local scaleY = mode.h / frame.h
+local guideWpt = 1920 / scaleX
+local guideHpt = 1080 / scaleY
+```
+
+macOS の「拡大表示」でも `currentMode()` から実サイズを取れるため、単純な `backingScaleFactor` より安全。
+
+### 6. OBS クロップ値のコピー
+
+対象ディスプレイのキャプチャ解像度と録画領域の位置から Left / Top / Right / Bottom をピクセル単位で算出し、以下の書式で `hs.pasteboard.setContents()` にセットする。
+
+```text
+OBS Crop
+Left: 960
+Top: 540
+Right: 960
+Bottom: 540
+Output: 1920x1080
+```
+
+### 7. 設定の永続化
+
+`hs.settings.set()` / `hs.settings.get()` を使い、以下を保存する:
+
+- `dimOutside` (bool, default true)
+- `dimOpacity` (float, default 0.55)
+- `borderWidth` (float, default 3)
+- `outputWidth` (int, default 1920)
+- `outputHeight` (int, default 1080)
+
+MVP では設定 UI は用意せず、値の変更は init.lua 内で定数を書き換える運用でよい。
+
+## モジュール API 案
+
+`recording_guide.lua` は require 時に即座にメニューバーを常駐させる副作用型モジュールとし、テーブルを返して外部から `show()` / `hide()` / `toggle()` / `copyCrop()` を叩けるようにする。
+
+```lua
+local M = require("recording_guide")
+M.show()
+M.hide()
+M.toggle()
+M.copyCrop()
+```
+
+## init.lua 変更
+
+末尾に 1 行追加するだけ。
+
+```lua
+require("recording_guide")
+```
+
+既存のコードには一切触らない。
+
+## bin/link.sh 変更
+
+`.hammerspoon` は既に TARGETS に含まれているはずなので、変更は不要。念のため確認する（含まれていなければ追加）。
+
+## 手動テスト項目
+
+### 起動
+
+- [ ] `hs.reload()` でエラーが出ない
+- [ ] メニューバーにアイコンが表示される
+- [ ] Dock アイコンが増えない
+
+### ガイド表示
+
+- [ ] Show Guide で 1920×1080 相当の透明領域 + 半透明暗幕が表示される
+- [ ] Hide Guide で消える
+- [ ] Center Guide でメインディスプレイ中央に移動する
+- [ ] 境界線が視認できる
+- [ ] Toggle Outside Dimming で暗幕の on/off が切り替わる
+- [ ] 録画領域内をクリックしても背面アプリ（VS Code / Terminal / ブラウザ）が通常操作できる
+- [ ] 録画領域外の暗幕部分をクリックしても背面が反応する（完全透過）
+
+### ディスプレイ
+
+- [ ] 4K ディスプレイ中央に配置される
+- [ ] Space を切り替えてもガイドが表示され続ける
+- [ ] フルスクリーンアプリを開いても消えない（`fullScreenAuxiliary`）
+- [ ] ディスプレイを抜き差ししてもクラッシュしない（`hs.screen.watcher` で再計算するのが理想、MVP では手動 `hs.reload()` でも可）
+
+### OBS 連携
+
+- [ ] Copy OBS Crop Values でクリップボードに指定書式がコピーされる
+- [ ] コピーされた値を OBS の Crop に貼って、ガイド枠と録画範囲が一致する
+- [ ] OBS 出力が 1920×1080 になり、文字がぼやけない
+
+## ファイル一覧
+
+### 新規作成（2 ファイル）
+
+- `.hammerspoon/recording_guide.lua` — モジュール本体（100〜150 行想定）
+- `docs/plans/add-recording-guide.md` — 本計画ドキュメント
+
+### 変更（1 ファイル）
+
+- `.hammerspoon/init.lua` — 末尾に `require("recording_guide")` を 1 行追加
+
+## 設計判断
+
+### なぜ Spoon にしないか
+
+- 既存の `.hammerspoon/hs/spaces.lua` や `init.lua` は素の Lua モジュールで統一されている
+- Spoons/ ディレクトリは現状空で、Spoon の慣例に従うメリットが薄い
+- 個人利用の単一機能を配布する意図がない
+- `require` 1 行で無効化できるシンプルさを優先
+
+### なぜ `hs.canvas` か（`hs.drawing` ではなく）
+
+- `hs.drawing` は deprecated 扱いで、公式は `hs.canvas` を推奨
+- `canvas:canvasMouseEvents()` で完全なクリック透過制御が可能
+- 抜き領域（even-odd fill）を素直に描ける
+
+### なぜ `currentMode()` ベースのスケーリングか
+
+- `backingScaleFactor` だけだと macOS の「拡大表示」で物理ピクセルと一致しない
+- Retina 環境下でも `mode.w / frame.w` は実際のスケール比を返すため、OBS のクロップ値と一致しやすい
+
+### なぜ MVP に設定 UI を作らないか
+
+- 個人利用のため、値の変更は init.lua で定数を書き換えれば十分
+- メニューバーに設定項目を並べ始めるとメニュー階層が膨らむ
+- 必要になった時点で `hs.dialog` などで追加可能
+
+## 元 spec との差分
+
+`fillin/recording-guide-app` の Swift 版 spec からスコープを外した項目:
+
+- **Xcode プロジェクト構成** — Hammerspoon には不要
+- **AppDelegate / NSPanel サブクラス** — `hs.canvas` に置換
+- **UserDefaults** — `hs.settings` に置換
+- **README / アーキテクチャドキュメント** — 本 plan ドキュメントに集約
+- **Quit メニュー** — Hammerspoon 本体が常駐するため不要
+
+Swift 版 spec の「12. Claude Code への実装指示」以降は Hammerspoon 版では読み替え不要。
+
+## ロールバック方法
+
+問題が発生した場合:
+
+1. `.hammerspoon/init.lua` から `require("recording_guide")` の 1 行を削除
+2. `.hammerspoon/recording_guide.lua` を削除
+3. `hs.reload()`
+
+依存追加は無いため、`brew` 側の変更は発生しない。
+
+## 参考リンク
+
+- [Hammerspoon hs.canvas](https://www.hammerspoon.org/docs/hs.canvas.html)
+- [Hammerspoon hs.menubar](https://www.hammerspoon.org/docs/hs.menubar.html)
+- [Hammerspoon hs.screen](https://www.hammerspoon.org/docs/hs.screen.html)
+- [Hammerspoon hs.pasteboard](https://www.hammerspoon.org/docs/hs.pasteboard.html)
+- [Hammerspoon hs.settings](https://www.hammerspoon.org/docs/hs.settings.html)
+- 元 spec: `../../fillin/recording-guide-app/docs/specs/recording-guide-app.md`


### PR DESCRIPTION
## Summary

- 4K 外部ディスプレイなど任意のスクリーン上に、YouTube 録画用の 1920×1080 相当のガイド枠を常時表示する Hammerspoon モジュールを追加
- OBS の Crop 値をワンクリックで clipboard にコピーする連携機能
- screencapture ベースのワンクリック録画機能 (マイク音声込み)
- メニューバー常駐で操作、ON/OFF・録画中は表示色で識別可能

## 実装

- `.hammerspoon/recording_guide.lua` を新規追加 (`hs.canvas` / `hs.menubar` / `hs.task`)
- `.hammerspoon/init.lua` 末尾に `require("recording_guide")` を追加
- 詳細な設計判断・元 spec との差分は `docs/plans/add-recording-guide.md` に集約

### 主な機能

- **ガイド表示**: `hs.canvas` overlay。クリック透過で背面アプリを通常操作可能。全 Space + フルスクリーン対応
- **ディスプレイ自動選択**: 複数接続時は物理ピクセル最大 (通常 4K) を自動選択。メニューから手動選択も可能で `hs.settings` に永続化
- **プレビュー縮小**: 対象ディスプレイに 1920×1080 が収まらない場合は 16:9 維持で最大化表示 (MBP 単体でも動作確認可能)
- **OBS 連携**: Copy OBS Crop Values で Left/Top/Right/Bottom をクリップボードへ
- **録画機能**: Start Recording (mic on) で `screencapture -v -g -R` を起動、Stop で SIGINT による clean stop → Finder で保存先を表示
- **メニューバー状態表示**:
  - OFF: `REC`
  - ガイド表示中: 灰背景 ` REC `
  - 録画中: 赤背景 ` ● REC `
- **reload 安全**: `_G` に state を保持し、`hs.reload()` 時は canvas/menubar/走行中の録画をクリーンアップしてから再構築

## Test plan

- [x] `luac -p` 通過
- [x] `hs.reload()` でエラーなし、メニューバー "REC" が出る
- [x] Show Guide で赤枠 + 外側暗幕が表示、Hide Guide で消える
- [x] Toggle Outside Dimming で暗幕 on/off
- [x] Target Display で選択ディスプレイに即反映
- [x] MBP 内蔵 (1512×982) 環境でプレビュー縮小表示を確認
- [x] ガイド枠内クリックで背面アプリを通常操作可能 (クリック透過)
- [ ] 4K 外部接続時に native 1920×1080 で表示され、Copy OBS Crop Values の値が OBS の Crop と一致することを確認
- [ ] Start Recording → Stop Recording で `~/Movies/recording-guide-*.mov` が保存され、マイク音声が入っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)