### PR TITLE
feat: recording_guide を OBS 録画向けに調整

### DIFF
--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -238,7 +238,8 @@ function M.startRecording()
 	local screen = getTargetScreen()
 	local g = computeGuide(screen)
 	if g.previewScale < 1 then
-		hs.alert.show("Preview mode: recording at scaled size, not 1920x1080")
+		local outW, outH = getOutputSize(screen)
+		hs.alert.show(string.format("Preview mode: recording at scaled size, not %dx%d", outW, outH))
 	end
 	local ts = os.date("%Y%m%d-%H%M%S")
 	local path = string.format("%s/Movies/recording-guide-%s.mov", os.getenv("HOME"), ts)

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -29,14 +29,22 @@ local OUTPUT_PRESETS = {
 	{ key = "3840x2160", label = "3840x2160 (4K)",  w = 3840, h = 2160 },
 }
 
--- framebuffer 幅 (mode.w * scale) の閾値で自動選択。
--- 例: 4K を「スペースを拡大」で使うと 6016 → 4K プリセットが選ばれる
+-- 対象ディスプレイに previewScale なしで収まる最大プリセットを採用。
+-- 例: LG 4K (3008x1692 pt, scale=2) → 4K, MBP Retina (1512x982 pt, scale=2) → QHD
 local function autoOutputSize(screen)
 	local mode = screen:currentMode()
-	local fbW = (mode.w or 0) * (mode.scale or 1)
-	if fbW >= 5120 then return 3840, 2160 end
-	if fbW >= 3840 then return 2560, 1440 end
-	return 1920, 1080
+	local frame = screen:fullFrame()
+	local scale = mode.scale or 1
+	local scaleX = (mode.w * scale) / frame.w
+	local scaleY = (mode.h * scale) / frame.h
+	for i = #OUTPUT_PRESETS, 1, -1 do
+		local p = OUTPUT_PRESETS[i]
+		if (p.w / scaleX) <= frame.w and (p.h / scaleY) <= frame.h then
+			return p.w, p.h
+		end
+	end
+	-- どれも収まらない場合は最小 (FHD) を返し previewScale に任せる
+	return OUTPUT_PRESETS[1].w, OUTPUT_PRESETS[1].h
 end
 
 local function getOutputSize(screen)

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -29,22 +29,24 @@ local OUTPUT_PRESETS = {
 	{ key = "3840x2160", label = "3840x2160 (4K)",  w = 3840, h = 2160 },
 }
 
--- 対象ディスプレイに previewScale なしで収まる最大プリセットを採用。
--- 例: LG 4K (3008x1692 pt, scale=2) → 4K, MBP Retina (1512x982 pt, scale=2) → QHD
+-- 対象ディスプレイの横幅目一杯を 16:9 で確保。
+-- 高さがはみ出す (極端に横長でないディスプレイでは起きない) 場合のみ高さ基準に切り替え。
+-- 物理ピクセルに換算、コーデックの偶数要件に合わせて 2 の倍数へ丸める。
 local function autoOutputSize(screen)
 	local mode = screen:currentMode()
 	local frame = screen:fullFrame()
 	local scale = mode.scale or 1
 	local scaleX = (mode.w * scale) / frame.w
 	local scaleY = (mode.h * scale) / frame.h
-	for i = #OUTPUT_PRESETS, 1, -1 do
-		local p = OUTPUT_PRESETS[i]
-		if (p.w / scaleX) <= frame.w and (p.h / scaleY) <= frame.h then
-			return p.w, p.h
-		end
+	local wPt = frame.w
+	local hPt = wPt * 9 / 16
+	if hPt > frame.h then
+		hPt = frame.h
+		wPt = hPt * 16 / 9
 	end
-	-- どれも収まらない場合は最小 (FHD) を返し previewScale に任せる
-	return OUTPUT_PRESETS[1].w, OUTPUT_PRESETS[1].h
+	local outW = math.floor(wPt * scaleX / 2 + 0.5) * 2
+	local outH = math.floor(hPt * scaleY / 2 + 0.5) * 2
+	return outW, outH
 end
 
 local function getOutputSize(screen)

--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -18,12 +18,37 @@ end
 
 local SETTINGS_PREFIX = "recording_guide."
 local DEFAULTS = {
-	outputWidth = 1920,
-	outputHeight = 1080,
-	dimOpacity = 0.2,
-	borderWidth = 3,
+	dimOpacity = 0.5,
 	dimOutside = true,
 }
+
+-- 出力サイズプリセット。auto は対象ディスプレイの framebuffer 幅で選ぶ
+local OUTPUT_PRESETS = {
+	{ key = "1920x1080", label = "1920x1080 (FHD)", w = 1920, h = 1080 },
+	{ key = "2560x1440", label = "2560x1440 (QHD)", w = 2560, h = 1440 },
+	{ key = "3840x2160", label = "3840x2160 (4K)",  w = 3840, h = 2160 },
+}
+
+-- framebuffer 幅 (mode.w * scale) の閾値で自動選択。
+-- 例: 4K を「スペースを拡大」で使うと 6016 → 4K プリセットが選ばれる
+local function autoOutputSize(screen)
+	local mode = screen:currentMode()
+	local fbW = (mode.w or 0) * (mode.scale or 1)
+	if fbW >= 5120 then return 3840, 2160 end
+	if fbW >= 3840 then return 2560, 1440 end
+	return 1920, 1080
+end
+
+local function getOutputSize(screen)
+	local key = hs.settings.get(SETTINGS_PREFIX .. "outputPreset")
+	if key == nil or key == "auto" then
+		return autoOutputSize(screen)
+	end
+	for _, p in ipairs(OUTPUT_PRESETS) do
+		if p.key == key then return p.w, p.h end
+	end
+	return autoOutputSize(screen)
+end
 
 local state = {
 	canvas = nil,
@@ -80,8 +105,7 @@ local function computeGuide(screen)
 	local modePxH = mode.h * scaleFactor
 	local scaleX = modePxW / frame.w
 	local scaleY = modePxH / frame.h
-	local outW = getSetting("outputWidth")
-	local outH = getSetting("outputHeight")
+	local outW, outH = getOutputSize(screen)
 	local guideWpt = outW / scaleX
 	local guideHpt = outH / scaleY
 	-- ディスプレイに収まらない場合はプレビュー用に 16:9 維持したまま縮小
@@ -154,15 +178,6 @@ local function rebuildCanvas()
 			frame = { x = localX + g.w, y = localY, w = frame.w - (localX + g.w), h = g.h },
 		}
 	end
-
-	-- 境界線
-	canvas[#canvas + 1] = {
-		type = "rectangle",
-		action = "stroke",
-		strokeColor = { red = 1, green = 0.2, blue = 0.2, alpha = 1 },
-		strokeWidth = getSetting("borderWidth"),
-		frame = { x = localX, y = localY, w = g.w, h = g.h },
-	}
 
 	state.canvas = canvas
 	-- 録画中はガイドを再表示しない (border/暗幕が録画に混入するため)
@@ -276,8 +291,7 @@ function M.copyCrop()
 		hs.alert.show("Preview mode: OBS crop values not accurate on this display")
 		return
 	end
-	local outW = getSetting("outputWidth")
-	local outH = getSetting("outputHeight")
+	local outW, outH = getOutputSize(screen)
 	local left = math.floor((g.x - g.screenFrame.x) * g.scaleX + 0.5)
 	local top = math.floor((g.y - g.screenFrame.y) * g.scaleY + 0.5)
 	local right = g.modeW - left - outW
@@ -320,6 +334,34 @@ local function targetDisplaySubmenu()
 	return items
 end
 
+local function outputSizeSubmenu()
+	local items = {}
+	local savedKey = hs.settings.get(SETTINGS_PREFIX .. "outputPreset") or "auto"
+	local screen = getTargetScreen()
+	local autoW, autoH = autoOutputSize(screen)
+	table.insert(items, {
+		title = string.format("Auto (%dx%d)", autoW, autoH),
+		checked = savedKey == "auto",
+		fn = function()
+			hs.settings.set(SETTINGS_PREFIX .. "outputPreset", "auto")
+			rebuildCanvas()
+		end,
+	})
+	table.insert(items, { title = "-" })
+	for _, p in ipairs(OUTPUT_PRESETS) do
+		local preset = p
+		table.insert(items, {
+			title = preset.label,
+			checked = savedKey == preset.key,
+			fn = function()
+				hs.settings.set(SETTINGS_PREFIX .. "outputPreset", preset.key)
+				rebuildCanvas()
+			end,
+		})
+	end
+	return items
+end
+
 local function buildMenubar()
 	local mb = hs.menubar.new()
 	if mb == nil then return nil end
@@ -333,6 +375,7 @@ local function buildMenubar()
 			{ title = "Center Guide", fn = M.center },
 			{ title = "-" },
 			{ title = "Toggle Outside Dimming", fn = M.toggleDimming, checked = state.dimOutside },
+			{ title = "Output Size", menu = outputSizeSubmenu() },
 			{ title = "Target Display", menu = targetDisplaySubmenu() },
 			{ title = "-" },
 			{ title = "Copy OBS Crop Values", fn = M.copyCrop },
@@ -342,5 +385,8 @@ local function buildMenubar()
 end
 
 state.menubar = buildMenubar()
+
+-- 起動時にガイドを表示 (位置は computeGuide で常に画面中央)
+M.show()
 
 return M


### PR DESCRIPTION
## Summary
- 起動時にガイドを自動表示 (中央固定)。以前は menubar から手動で Show する必要があった
- 出力サイズをプリセット化 + `auto` モードを追加
  - 対象ディスプレイの framebuffer 幅 (`mode.w * scale`) で FHD / QHD / 4K を自動選択
  - 「スペースを拡大」等で framebuffer が大きい 4K でも視認性のあるサイズで表示される
  - menubar の Output Size から `1920x1080` / `2560x1440` / `3840x2160` に手動 override 可能
- OBS Display Capture への写り込みを避けるため赤枠 stroke を削除
- 境界視認性を保つため枠外の暗幕を 0.2 → 0.5 opacity に強調

## Test plan
- [ ] `hs.reload()` 後、対象ディスプレイ中央にガイドが出る
- [ ] Output Size サブメニューから任意プリセット / Auto に切り替えできる
- [ ] LG 4K を 3008x1692 で使用時、auto で 3840x2160 プリセットが選ばれる (framebuffer 6016 >= 5120)
- [ ] OBS Display Capture で録画しても赤い枠線が映り込まない
- [ ] `Copy OBS Crop Values` の値が現在のプリセットで正しく計算される