### PR TITLE
feat(opencode): OpenCode に tmux agent-status Plugin を追加

### DIFF
--- a/.config/opencode/plugins/tmux-status.js
+++ b/.config/opencode/plugins/tmux-status.js
@@ -1,0 +1,13 @@
+export const TmuxStatusPlugin = async ({ $ }) => {
+  return {
+    "session.idle": async () => {
+      await $`sh ~/.tmux/agent-status.sh idle`.quiet();
+    },
+    "tool.execute.before": async () => {
+      await $`sh ~/.tmux/agent-status.sh working`.quiet();
+    },
+    "session.error": async () => {
+      await $`sh ~/.tmux/agent-status.sh blocked`.quiet();
+    },
+  };
+};

--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ mac: ## Apply Macbook Setting
 	sh ./bin/mac.sh
 
 .PHONY: agent_hooks
-agent_hooks: ## Install AI agent status hooks (Claude Code / Codex)
+agent_hooks: ## Install AI agent status hooks (Claude Code / Codex / OpenCode)
 	sh ./bin/agent_hooks.sh
 
 .PHONY: agent_hooks_uninstall

--- a/bin/agent_hooks.sh
+++ b/bin/agent_hooks.sh
@@ -1,11 +1,13 @@
 #!/bin/sh
 
-# Install / uninstall AI agent hooks for Claude Code and Codex.
+# Install / uninstall AI agent hooks for Claude Code, Codex, and OpenCode.
 #
 # Manages:
 #   - tmux status hooks (agent-status.sh) for both CLIs
 #   - shared notification sound (~/.agents/hooks/notify-sound.sh)
 #   - Codex-only protected-file and force-push guards
+#   - OpenCode tmux status plugin (.config/opencode/plugins/tmux-status.js)
+#     is self-contained and auto-loaded; no registration step needed.
 #
 # Unrelated hook entries (e.g. Claude Code's existing guard-protected-files.sh
 # / guard-force-push.sh under ~/.claude/hooks/) are preserved on both install


### PR DESCRIPTION
## 概要

OpenCode の Plugin システムを使って、tmux ペインにエージェントの動作状態（idle / working / blocked）を表示します。

## 変更内容

- `.config/opencode/plugins/tmux-status.js` を新規追加
  - `session.idle` → agent-status.sh idle
  - `tool.execute.before` → agent-status.sh working
  - `session.error` → agent-status.sh blocked
- `Makefile` の `agent_hooks` ターゲット説明文に OpenCode を追記
- `bin/agent_hooks.sh` のヘッダコメントに OpenCode の説明を追記

## 備考

- Claude Code / Codex と異なり、Plugin は `.config/opencode/plugins/` に配置するだけで自動ロードされるため、`agent_hooks.sh` での登録手順は不要です。
- SessionEnd 相当のプロセス終了フックは opencode に存在しないため、`agent-status.sh clear` は tmux の `pane-died-hook` またはシェルラッパーで対応する想定です。