### PR TITLE
fix(tmux): prevent copy-mode entry on alternate screen scroll

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -49,8 +49,8 @@ bind -T copy-mode-vi WheelDownPane select-pane \; send-keys -X -N 2 scroll-down
 
 # Mouse wheel scrolling in normal mode (enters copy mode automatically)
 # Simplified for faster response
-bind -n WheelUpPane if-shell -Ft= "#{pane_in_mode}" "send-keys -M" "copy-mode -et="
-bind -n WheelDownPane send-keys -M
+bind -n WheelUpPane if-shell -Ft= "#{pane_in_mode}" "send-keys -M" "if -Ft= '#{alternate_on}' 'send-keys -M' 'copy-mode -et='"
+bind -n WheelDownPane if-shell -Ft= "#{pane_in_mode}" "send-keys -M" "if -Ft= '#{alternate_on}' 'send-keys -M' ''"
 
 # focus events
 set -g focus-events on


### PR DESCRIPTION
## Summary

tmux の通常モードでマウスホイール操作時に、alternate screen (`less` や `vim` 等) では copy-mode に入らずスクロールイベントをアプリケーションにそのまま渡すように修正。

## Key Changes

- `WheelUpPane` / `WheelDownPane`: `pane_in_mode` でない場合に `alternate_on` をチェックし、alternate screen 中なら `send-keys -M` でアプリケーションに伝達、それ以外は copy-mode に移行

## Impact

- `less` や `vim` など alternate screen を使うアプリケーションで意図しない copy-mode 移行が防止される
- 通常のシェル表示でのスクロール動作 (copy-mode 移行) は変更なし
