### PR TITLE
fix(hammerspoon): 起動時に録画ガイドが自動表示されるのを修正

### DIFF
--- a/.hammerspoon/recording_guide.lua
+++ b/.hammerspoon/recording_guide.lua
@@ -397,7 +397,4 @@ end
 
 state.menubar = buildMenubar()
 
--- 起動時にガイドを表示 (位置は computeGuide で常に画面中央)
-M.show()
-
 return M


### PR DESCRIPTION
## Summary

Hammerspoon 起動時（PC ログイン時）に録画ガイドオーバーレイが自動表示される問題を修正。`M.show()` の呼び出しを削除し、ガイドはメニューバーから手動でのみ表示するよう変更。

## Key Changes

- `.hammerspoon/recording_guide.lua`: 末尾の `M.show()` とその説明コメント（3行）を削除

## Impact

- 既存の手動 Show Guide / Hide Guide 機能に影響なし
- メニューバーアイコン "REC" は引き続き常駐
