### PR TITLE
feat: herdr を tmux の挙動に合わせて導入

### DIFF
--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -8,6 +8,11 @@
 #
 # 既定値一覧は `herdr --default-config`, 検証は `herdr config check` で確認できる。
 
+# 初回起動時の通知セットアップ (onboarding) を出さない。
+# 未指定または true だと起動のたびに onboarding が走り, 完了時に herdr 自身が
+# この行をファイル先頭へ追記するため, あらかじめここで明示しておく。
+onboarding = false
+
 [theme]
 # tmux は端末のカラーパレットをそのまま使うため, 同じ挙動になる "terminal" を採用。
 # Ghostty 側のテーマ (TokyoNight) に揃えたい場合は "tokyo-night" に変更する。

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -1,0 +1,149 @@
+# herdr configuration
+#
+# tmux (~/.tmux.conf) の操作感に可能な限り寄せた設定。
+# 既定値と同じ項目も「tmux と一致していること」を明示するために意図的に書いている。
+#
+# tmux にはない herdr 固有の機能 (sidebar / workspace / worktree / agent 検知) は
+# herdr の既定キーをそのまま採用している。
+#
+# 既定値一覧は `herdr --default-config`, 検証は `herdr config check` で確認できる。
+
+[theme]
+# tmux は端末のカラーパレットをそのまま使うため, 同じ挙動になる "terminal" を採用。
+# Ghostty 側のテーマ (TokyoNight) に揃えたい場合は "tokyo-night" に変更する。
+name = "terminal"
+
+[terminal]
+# tmux: split-window / new-window に -c "#{pane_current_path}" を付けているのと同じ挙動。
+new_cwd = "follow"
+
+# tmux は macOS では login shell を起動する。"auto" が同じ挙動。
+shell_mode = "auto"
+
+[keys]
+# tmux: set-option -g prefix C-e
+prefix = "ctrl+e"
+
+# --- prefix mode: tmux と一致するもの ---
+# tmux: bind ? list-keys
+help = "prefix+?"
+# tmux: bind d detach-client
+detach = "prefix+d"
+# tmux: bind r source-file ~/.tmux.conf
+reload_config = "prefix+r"
+# tmux: bind w choose-tree (window/session 一覧)
+workspace_picker = "prefix+w"
+# tmux: bind i display-panes (pane 番号を出して飛ぶ) に相当する herdr の navigate mode
+goto = "prefix+i"
+# tmux: bind c new-window -c "#{pane_current_path}"
+new_tab = "prefix+c"
+# tmux: bind , rename-window
+rename_tab = "prefix+comma"
+# tmux: bind p previous-window
+previous_tab = "prefix+p"
+# tmux: bind n next-window (この設定では prefix+C-n も next-window だが herdr は 1 action 1 binding)
+next_tab = "prefix+n"
+# tmux: bind 1..9 select-window (base-index 1 と一致)
+switch_tab = "prefix+1..9"
+# tmux: bind h/j/k/l select-pane -L/-D/-U/-R
+focus_pane_left = "prefix+h"
+focus_pane_down = "prefix+j"
+focus_pane_up = "prefix+k"
+focus_pane_right = "prefix+l"
+# tmux: bind - split-window -vc "#{pane_current_path}" (上下分割)
+split_horizontal = "prefix+minus"
+# tmux: bind \ split-window -hc "#{pane_current_path}" (左右分割)
+split_vertical = "prefix+backslash"
+# tmux: bind z kill-pane (herdr 既定の prefix+x から移動)
+close_pane = "prefix+z"
+# tmux: bind y copy-mode
+# ※ copy_mode は `herdr --default-config` には出てこないが 0.8.0 で有効な action
+copy_mode = "prefix+y"
+
+# --- prefix mode: tmux に対応するものがなく調整したもの ---
+# tmux 側で prefix+z は kill-pane に潰しているため zoom は shift 付きへ退避。
+zoom = "prefix+shift+z"
+# tmux の resize-pane (prefix+H/J/K/L) 相当。prefix+r を reload に譲ったのでこちらへ。
+# 入ったあとは h/j/k/l でリサイズ, esc で抜ける。
+resize_mode = "prefix+shift+r"
+
+# --- herdr 固有機能: 既定のまま ---
+settings = "prefix+s"
+toggle_sidebar = "prefix+b"
+new_workspace = "prefix+shift+n"
+rename_workspace = "prefix+shift+w"
+close_workspace = "prefix+shift+d"
+new_worktree = "prefix+shift+g"
+rename_pane = "prefix+shift+p"
+edit_scrollback = "prefix+e"
+close_tab = "prefix+shift+x"
+cycle_pane_next = "prefix+tab"
+cycle_pane_previous = "prefix+shift+tab"
+open_notification_target = "prefix+o"
+
+# navigate mode 内の移動 (herdr 既定が既に vi 風なのでそのまま)
+navigate_pane_left = "h"
+navigate_pane_down = "j"
+navigate_pane_up = "k"
+navigate_pane_right = "l"
+
+# tmux: bind g display-popup -d '#{pane_current_path}' -w98% -h98% -E lazygit
+# popup は起動元 pane の cwd を引き継ぐため -d 相当の指定は不要。
+[[keys.command]]
+key = "prefix+g"
+type = "popup"
+command = "lazygit"
+width = "98%"
+height = "98%"
+
+[ui]
+# tmux: status bar は既定で画面下部 (status-position bottom)
+tab_bar_position = "bottom"
+
+# tmux: set -g mouse on
+mouse_capture = true
+
+# tmux の MouseDragEnd1Pane 既定 (ドラッグ選択でバッファへコピー) と同じ挙動。
+copy_on_select = true
+
+# tmux: bind -T copy-mode-vi WheelUpPane ... -N 2 scroll-up (既定 5 行から 2 行へ落としている)
+mouse_scroll_lines = 2
+
+# tmux: bind c new-window は名前を聞かずに即作成する
+prompt_new_tab_name = false
+
+# tmux: pane-border-lines simple 相当。tmux は pane 間に隙間を作らないので gaps は無効。
+pane_borders = true
+pane_gaps = false
+
+# tmux: setw -g window-status-current-style fg=green
+accent = "green"
+
+# tmux: kill-window 系は確認を挟むのでそのまま有効
+confirm_close = true
+
+# tmux に相当する通知機構がないため無効化 (状態は sidebar で確認する)
+[ui.toast]
+delivery = "off"
+
+[ui.sound]
+enabled = false
+
+[session]
+# tmux が server 再起動をまたいで pane を維持するのに近い挙動
+resume_agents_on_restore = true
+
+[experimental]
+# 日本語 IME on のまま prefix を押しても取りこぼさないようにする (macOS)。
+# tmux では端末が ctrl+e をそのまま渡すため意識せずに済んでいた挙動を再現する。
+switch_ascii_input_source_in_prefix = true
+
+# Claude Code / Codex など自前でカーソルを描く TUI で, IME の変換候補ウィンドウが
+# 追従しない場合は以下を有効化する (vim の normal mode などで余分なカーソルが出る副作用あり)。
+# reveal_hidden_cursor_for_cjk_ime = true
+# cjk_ime_agents = ["claude", "codex", "copilot"]
+
+[advanced]
+# tmux: set -g history-limit 25000 (herdr は行数ではなくバイト数指定)。
+# 既定の 10MB でおおよそ 25000 行以上を保持できるため既定のままにしている。
+# scrollback_limit_bytes = 10000000

--- a/.config/herdr/config.toml
+++ b/.config/herdr/config.toml
@@ -105,6 +105,22 @@ height = "98%"
 # tmux: status bar は既定で画面下部 (status-position bottom)
 tab_bar_position = "bottom"
 
+# tmux は agent 状態を status line の `▌` 1 文字で出しており横幅を食わない。
+# 同じ感覚にするため sidebar は畳んだ状態で起動し, "compact" の細い status rail
+# だけ残す (agent の state icon はここに出るので一覧性は保たれる)。
+# 中身を見たいときは prefix+b (toggle_sidebar) で開く。
+# 完全に幅 0 にしたい場合は sidebar_collapsed_mode = "hidden"。
+sidebar_start_collapsed = true
+sidebar_collapsed_mode = "compact"
+
+# 展開したときの幅。既定より狭めて, 開いても本文が潰れにくいようにする。
+sidebar_width = 22
+sidebar_min_width = 18
+sidebar_max_width = 30
+
+# tmux の pane にスクロールバーはない。無効にすると 1 桁ぶん本文に回せる。
+pane_scrollbars = false
+
 # tmux: set -g mouse on
 mouse_capture = true
 

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,12 @@
 !.claude/statusline.sh
 .antigravitycli/
 
+# herdr が各マシンで自動生成する agent 連携 hook / plugin
+# (`herdr integration install` や初回 onboarding で配置され, herdr の
+#  integration version が上がるたびに上書きされるため管理対象外とする)
+.claude/hooks/herdr-agent-state.sh
+.config/opencode/plugins/herdr-agent-state.js
+
 # webdata-node dependencies
 .zsh/bin/webdata-node/node_modules/
 

--- a/.zshrc
+++ b/.zshrc
@@ -181,6 +181,7 @@ if (( $+commands[pnpm] )); then
 fi
 (( $+commands[codex] )) && source <(codex completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[claude] )) && source "$HOME/.zsh/completions/_claude" 2>/dev/null
+(( $+commands[herdr] )) && source <(herdr completion zsh 2>/dev/null) 2>/dev/null
 (( $+commands[qr] )) && alias qr="qrencode -t UTF8"
 (( $+commands[uv] )) && eval "$(uv generate-shell-completion zsh 2>/dev/null)" 2>/dev/null
 if (( $+commands[nvim] )); then

--- a/bin/homebrew/cli.sh
+++ b/bin/homebrew/cli.sh
@@ -24,6 +24,7 @@ brew install \
           gnu-sed \
           gossm \
           grep \
+          herdr \
           font-symbols-only-nerd-font \
           fzf \
           htop \

--- a/bin/link.sh
+++ b/bin/link.sh
@@ -15,6 +15,8 @@ if [ ! -d $HOME/.config ]; then
 fi
 
 CURRENT_DIR=`pwd`
+# NOTE: `.config/herdr` は herdr が socket / log / session.json を同じディレクトリに
+#       作るため, ディレクトリごとではなく config.toml 単体をリンクする
 TARGETS=( \
          ".asdfrc" \
          ".gemrc" \
@@ -32,6 +34,7 @@ TARGETS=( \
          ".zshenv" \
          ".psqlrc" \
          ".config/ghostty" \
+         ".config/herdr/config.toml" \
          ".config/nvim" \
          ".config/opencode" \
          ".hammerspoon" \


### PR DESCRIPTION
## Summary

tmux から herdr へ試験的に移行するため、herdr (0.8.0) の設定ファイルを追加した。既存の `.tmux.conf` の keybinding / 挙動に可能な限り追従させ、dotfiles の link / homebrew / zsh 補完の各経路にも組み込んでいる。

## Key Changes

### `.config/herdr/config.toml` (新規)

tmux と一致させた binding:

| tmux | herdr |
|---|---|
| prefix `C-e` | `prefix = "ctrl+e"` |
| `h/j/k/l` select-pane | `focus_pane_left/down/up/right` |
| `\` split-window -h / `-` split-window -v | `split_vertical` / `split_horizontal` |
| `z` kill-pane | `close_pane = "prefix+z"` |
| `r` source-file | `reload_config = "prefix+r"` |
| `y` copy-mode | `copy_mode = "prefix+y"` |
| `c` new-window / `,` rename-window | `new_tab` / `rename_tab = "prefix+comma"` |
| `n` / `p` / `1..9` | `next_tab` / `previous_tab` / `switch_tab` |
| `d` detach / `w` choose-tree / `?` list-keys | `detach` / `workspace_picker` / `help` |
| `i` display-panes | `goto = "prefix+i"` |
| `g` lazygit popup 98%x98% | `[[keys.command]]` type = "popup" |

tmux と衝突するため意図的にずらした binding:

- `zoom` を `prefix+shift+z` へ退避 (tmux 側で `prefix+z` を kill-pane に潰しているため)
- `resize_mode` を `prefix+shift+r` へ退避 (`prefix+r` を reload に譲ったため)

その他の挙動合わせ:

- `new_cwd = "follow"` — tmux の `-c "#{pane_current_path}"` 相当
- `mouse_scroll_lines = 2` — tmux の `send-keys -X -N 2 scroll-up` 相当
- `mouse_capture` / `copy_on_select` — `set -g mouse on` と MouseDragEnd 既定相当
- `prompt_new_tab_name = false` — tmux の `new-window` が名前を聞かない挙動に合わせる
- `tab_bar_position = "bottom"` / `pane_gaps = false` / `accent = "green"` — status bar 位置・pane border・current window 色に追従
- `theme.name = "terminal"` — tmux が端末パレットをそのまま使う挙動に合わせる
- `switch_ascii_input_source_in_prefix = true` — 日本語 IME on でも prefix を取りこぼさないようにする

### その他

- `bin/link.sh`: `.config/herdr/config.toml` を TARGETS に追加。`~/.config/herdr/` には socket / log / `session.json` が同居するため、ディレクトリごとではなくファイル単体でリンクする
- `bin/homebrew/cli.sh`: `herdr` を追加
- `.zshrc`: `herdr completion zsh` を追加 (既存の codex / uv と同じ遅延読み込みパターン)

## Impact

- 既存の tmux 設定には一切手を入れていないため、tmux 側の挙動に影響はない
- `split_vertical` / `split_horizontal` の向きは herdr のドキュメントに明記がなく、既定値 `split_horizontal = "prefix+minus"` が tmux の `-` (上下分割) と一致することから「vertical = 左右分割」と判断している。実機で逆だった場合はこの 2 行を入れ替える必要がある
- `copy_mode` は `herdr --default-config` の出力には含まれないが 0.8.0 で有効な action。`herdr config check` で binding が有効であることを確認済み
- herdr を tmux の中で起動すると prefix `C-e` が二重になる
- `herdr integration install` (Claude Code 等の公式連携) は副作用があるため本 PR では実行していない

## Verification

- `herdr config check` -> `config: ok` (不正キー名を混入させると `invalid keybinding` を検出することも確認済みのため、全 binding が有効と判断できる)
- `sh -n bin/link.sh` / `sh -n bin/homebrew/cli.sh` / `zsh -n .zshrc` -> いずれも syntax ok
- `bash bin/link.sh` -> `exist: /Users/<user>/.config/herdr/config.toml` (既存 symlink を検出、リンク構造は正常)
- `zsh -i` で zshrc 読み込みと `_herdr` 補完関数の登録を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## 追記 (2 コミット目)

herdr 初回起動 (onboarding) が走ったことで判明した点を追加で反映した。

- `config.toml` に `onboarding = false` を明示。未指定 / `true` だと onboarding 完了時に herdr 自身がファイル先頭へこの行を追記してくるため、あらかじめ意図した位置に置いてコメントを添えている
- herdr の integration 自動インストールにより、symlink 経由で dotfiles リポジトリ内に生成物が 2 つ出現したため `.gitignore` に追加した
  - `.claude/hooks/herdr-agent-state.sh`
  - `.config/opencode/plugins/herdr-agent-state.js`

いずれもファイル冒頭に `managed by herdr; reinstalling or updating the integration overwrites this file.` と `HERDR_INTEGRATION_VERSION=N` を持つ herdr 管理の生成物で、各マシンで `herdr integration install` / onboarding 時に自動配置される。バージョン更新のたびに差分が出るためリポジトリ管理対象から外す判断とした。
