### PR TITLE
refactor(wtr): worktree の作成先を .git/wtr へ変更

### DIFF
--- a/.claude/hooks/guard-protected-files.sh
+++ b/.claude/hooks/guard-protected-files.sh
@@ -16,6 +16,9 @@
 #   - lockfile 系: package-lock.json, yarn.lock, pnpm-lock.yaml,
 #                  Cargo.lock, go.sum, composer.lock
 #   - .git/ 配下（オブジェクトや参照の直接編集）
+#     ただし .git/wtr/ 配下は wtr が作る worktree の作業ツリーであり、
+#     git の内部データではないため保護対象から除外する
+#     （除外しないと worktree 内のソース編集が全面的にブロックされる）
 #
 # 挙動:
 #   - 該当時は stdout に JSON {"decision":"block","reason":"..."} を出力
@@ -34,7 +37,16 @@ file_path=$(jq -r '.tool_input.file_path // empty')
 [ -z "$file_path" ] && exit 0
 
 # 保護対象パターン
-if echo "$file_path" | grep -qE '(^|/)(\.env(\.[^/]+)?|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock)$|/\.git/'; then
+# ファイル名ベースの保護（場所を問わず、worktree 内でも適用する）
+PROTECTED_NAME='(^|/)(\.env(\.[^/]+)?|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock)$'
+# git の内部データ
+GIT_INTERNAL='/\.git/'
+# wtr が作る worktree の作業ツリー（GIT_INTERNAL から除外する）
+GIT_WORKTREE='/\.git/wtr/'
+
+if echo "$file_path" | grep -qE "$PROTECTED_NAME" \
+  || { echo "$file_path" | grep -qE "$GIT_INTERNAL" \
+       && ! echo "$file_path" | grep -qE "$GIT_WORKTREE"; }; then
   cat <<EOF
 {"decision":"block","reason":"guard-protected-files: '$file_path' is a protected file (.env / lockfile / .git). Do not edit directly. If regeneration is needed, run the appropriate package manager or migration command instead, and confirm with the user first."}
 EOF

--- a/.claude/hooks/guard-protected-files.sh
+++ b/.claude/hooks/guard-protected-files.sh
@@ -16,9 +16,10 @@
 #   - lockfile 系: package-lock.json, yarn.lock, pnpm-lock.yaml,
 #                  Cargo.lock, go.sum, composer.lock
 #   - .git/ 配下（オブジェクトや参照の直接編集）
-#     ただし .git/wtr/ 配下は wtr が作る worktree の作業ツリーであり、
-#     git の内部データではないため保護対象から除外する
+#     ただし <git-common-dir>/wtr/ 配下は wtr が作る worktree の作業ツリー
+#     であり、git の内部データではないため保護対象から除外する
 #     （除外しないと worktree 内のソース編集が全面的にブロックされる）
+#     除外対象でも worktree 直下の .git ポインターファイルは保護を維持する
 #
 # 挙動:
 #   - 該当時は stdout に JSON {"decision":"block","reason":"..."} を出力
@@ -38,11 +39,16 @@ file_path=$(jq -r '.tool_input.file_path // empty')
 
 # 保護対象パターン
 # ファイル名ベースの保護（場所を問わず、worktree 内でも適用する）
-PROTECTED_NAME='(^|/)(\.env(\.[^/]+)?|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock)$'
+# `.git` 自体も含める: worktree 直下の .git は
+# `<git-common-dir>/worktrees/<name>` へのポインターで、
+# 書き換えると worktree が使用不能になる
+PROTECTED_NAME='(^|/)(\.env(\.[^/]+)?|\.git|package-lock\.json|yarn\.lock|pnpm-lock\.yaml|Cargo\.lock|go\.sum|composer\.lock)$'
 # git の内部データ
 GIT_INTERNAL='/\.git/'
 # wtr が作る worktree の作業ツリー（GIT_INTERNAL から除外する）
-GIT_WORKTREE='/\.git/wtr/'
+# submodule では common-dir が <super>/.git/modules/<name> になるため、
+# `.git/wtr/` と `.git/modules/<name>/wtr/`（ネストも可）の両方を許容する
+GIT_WORKTREE='/\.git/(modules/[^/]+/)*wtr/'
 
 if echo "$file_path" | grep -qE "$PROTECTED_NAME" \
   || { echo "$file_path" | grep -qE "$GIT_INTERNAL" \

--- a/.claude/hooks/guard-protected-files.sh
+++ b/.claude/hooks/guard-protected-files.sh
@@ -46,13 +46,30 @@ PROTECTED_NAME='(^|/)(\.env(\.[^/]+)?|\.git|package-lock\.json|yarn\.lock|pnpm-l
 # git の内部データ
 GIT_INTERNAL='/\.git/'
 # wtr が作る worktree の作業ツリー（GIT_INTERNAL から除外する）
-# submodule では common-dir が <super>/.git/modules/<name> になるため、
-# `.git/wtr/` と `.git/modules/<name>/wtr/`（ネストも可）の両方を許容する
-GIT_WORKTREE='/\.git/(modules/[^/]+/)*wtr/'
+# submodule では common-dir が <super>/.git/modules/<submodule-path> になる。
+# <submodule-path> は `libs/foo` のように複数階層を取りうるため `.+` で受ける
+GIT_WORKTREE='/\.git/(modules/.+/)?wtr/'
+# `..` 成分を含むパス
+DOTDOT='(^|/)\.\.(/|$)'
 
-if echo "$file_path" | grep -qE "$PROTECTED_NAME" \
-  || { echo "$file_path" | grep -qE "$GIT_INTERNAL" \
-       && ! echo "$file_path" | grep -qE "$GIT_WORKTREE"; }; then
+matches() {
+  echo "$file_path" | grep -qE "$1"
+}
+
+block=false
+if matches "$PROTECTED_NAME"; then
+  block=true
+elif matches "$GIT_INTERNAL"; then
+  block=true
+  # worktree の作業ツリーは git の内部データではないので保護対象から外す。
+  # ただし `..` を含むパスは正規化すると内部へ抜けられるため除外しない
+  # (例: `<repo>/.git/wtr/../config` は実際には .git/config を指す)。
+  if matches "$GIT_WORKTREE" && ! matches "$DOTDOT"; then
+    block=false
+  fi
+fi
+
+if [ "$block" = true ]; then
   cat <<EOF
 {"decision":"block","reason":"guard-protected-files: '$file_path' is a protected file (.env / lockfile / .git). Do not edit directly. If regeneration is needed, run the appropriate package manager or migration command instead, and confirm with the user first."}
 EOF

--- a/.zsh/functions/wtr
+++ b/.zsh/functions/wtr
@@ -92,13 +92,26 @@ _ymt_wtr_get_main_worktree() {
 # 共通 git ディレクトリを基準にすることで、worktree 内から実行した場合や
 # .git がファイル (submodule 等) の場合でも同じ場所に解決される。
 _ymt_wtr_get_worktrees_dir() {
-  local common_dir
-  common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+  local common_dir=""
+  local raw
+  local -a out
 
-  # git < 2.31 は --path-format 非対応。相対パスで返るため自前で絶対化する。
+  # git >= 2.31 は --path-format=absolute で絶対パスを 1 行返す。
+  # git < 2.31 は --path-format を未知オプションとして stdout へそのまま
+  # echo back したうえで exit 0 するため、空判定だけでは fallback に落ちず
+  # 不正なパスをそのまま採用してしまう。「1 行の絶対パス」であることを
+  # 検証してから採用する。
+  out=(${(f)"$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)"})
+  if (( ${#out[@]} == 1 )) && [[ "${out[1]}" == /* ]]; then
+    common_dir="${out[1]}"
+  fi
+
+  # fallback: --git-common-dir 単体は相対パスを返すことがあるため絶対化する。
   if [[ -z "$common_dir" ]]; then
-    common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
-    [[ -z "$common_dir" ]] && return 1
+    raw=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+    out=(${(f)raw})
+    (( ${#out[@]} == 1 )) || return 1
+    common_dir="${out[1]}"
     if [[ "$common_dir" != /* ]]; then
       common_dir="$(cd "$common_dir" 2>/dev/null && pwd)" || return 1
     fi

--- a/.zsh/functions/wtr
+++ b/.zsh/functions/wtr
@@ -209,6 +209,19 @@ _ymt_wtr_add() {
     worktree_name="${branch_name//\//-}"
   fi
 
+  # 作成先は <git-common-dir>/wtr 配下なので、明示 name による脱出を禁止する。
+  # 許すと `wtr add x ../refs/foo` のように .git の内部領域へ worktree を
+  # 作成でき、refs や objects を破壊し得る。
+  if [[ "$worktree_name" == /* ]] \
+    || [[ "$worktree_name" == ".." ]] \
+    || [[ "$worktree_name" == "../"* ]] \
+    || [[ "$worktree_name" == *"/.." ]] \
+    || [[ "$worktree_name" == *"/../"* ]]; then
+    echo "Error: Invalid worktree name: $worktree_name" >&2
+    echo "       Absolute paths and '..' components are not allowed." >&2
+    return 1
+  fi
+
   # --base without value: fzf branch selection
   if [[ "$base_flag_set" == true && -z "$base_branch" ]]; then
     if ! (( $+commands[fzf] )); then

--- a/.zsh/functions/wtr
+++ b/.zsh/functions/wtr
@@ -210,15 +210,23 @@ _ymt_wtr_add() {
   fi
 
   # 作成先は <git-common-dir>/wtr 配下なので、明示 name による脱出を禁止する。
-  # 許すと `wtr add x ../refs/foo` のように .git の内部領域へ worktree を
-  # 作成でき、refs や objects を破壊し得る。
-  if [[ "$worktree_name" == /* ]] \
-    || [[ "$worktree_name" == ".." ]] \
-    || [[ "$worktree_name" == "../"* ]] \
-    || [[ "$worktree_name" == *"/.." ]] \
-    || [[ "$worktree_name" == *"/../"* ]]; then
+  # `..` を許すと `wtr add x ../refs/foo` のように .git の内部領域へ worktree
+  # を作成でき refs や objects を破壊し得る。`.` を許すと作成先が wtr
+  # ディレクトリ自体になり、以降の worktree がその配下にネストする。
+  local -a name_parts
+  name_parts=(${(s:/:)worktree_name})
+  local invalid_name=false
+  local part
+
+  [[ "$worktree_name" == /* ]] && invalid_name=true
+  (( ${#name_parts[@]} == 0 )) && invalid_name=true
+  for part in "${name_parts[@]}"; do
+    [[ "$part" == "." || "$part" == ".." ]] && invalid_name=true
+  done
+
+  if [[ "$invalid_name" == true ]]; then
     echo "Error: Invalid worktree name: $worktree_name" >&2
-    echo "       Absolute paths and '..' components are not allowed." >&2
+    echo "       Absolute paths and '.' / '..' components are not allowed." >&2
     return 1
   fi
 

--- a/.zsh/functions/wtr
+++ b/.zsh/functions/wtr
@@ -27,10 +27,14 @@ Options:
     -y, --yes          (copy) skip overwrite confirmation
 
 Worktree layout:
-    New worktrees are created at:
-        <parent>/<repo>.worktrees/<name>
+    New worktrees are created under the repository's git directory:
+        <git-common-dir>/wtr/<name>
     Example:
-        ~/Project/Personal/dotfiles.worktrees/feat-x
+        ~/Project/Personal/dotfiles/.git/wtr/feat-x
+
+    Living inside .git keeps worktrees out of the parent directory and
+    invisible to git status / git clean / ripgrep without any .gitignore.
+    Note that removing .git also removes every worktree under it.
 
 Auto-symlinked paths (if present in main repo):
     .claude/skills   -> <worktree>/.claude/skills
@@ -84,8 +88,23 @@ _ymt_wtr_get_main_worktree() {
   git worktree list | head -n 1 | awk '{print $1}'
 }
 
-_ymt_wtr_get_repo_name() {
-  basename "$(_ymt_wtr_get_main_worktree)"
+# worktree の作成先ディレクトリ (<git-common-dir>/wtr) を絶対パスで返す。
+# 共通 git ディレクトリを基準にすることで、worktree 内から実行した場合や
+# .git がファイル (submodule 等) の場合でも同じ場所に解決される。
+_ymt_wtr_get_worktrees_dir() {
+  local common_dir
+  common_dir=$(git rev-parse --path-format=absolute --git-common-dir 2>/dev/null)
+
+  # git < 2.31 は --path-format 非対応。相対パスで返るため自前で絶対化する。
+  if [[ -z "$common_dir" ]]; then
+    common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || return 1
+    [[ -z "$common_dir" ]] && return 1
+    if [[ "$common_dir" != /* ]]; then
+      common_dir="$(cd "$common_dir" 2>/dev/null && pwd)" || return 1
+    fi
+  fi
+
+  echo "${common_dir}/wtr"
 }
 
 _ymt_wtr_detect_copy_files() {
@@ -195,21 +214,19 @@ _ymt_wtr_add() {
     fi
   fi
 
-  local repo_name
-  repo_name=$(_ymt_wtr_get_repo_name)
-  if [[ $? -ne 0 ]]; then
-    return 1
-  fi
-
   local main_worktree
   main_worktree=$(_ymt_wtr_get_main_worktree)
   if [[ $? -ne 0 ]]; then
     return 1
   fi
 
-  local parent_dir
-  parent_dir="$(dirname "$main_worktree")"
-  local worktrees_dir="${parent_dir}/${repo_name}.worktrees"
+  local worktrees_dir
+  worktrees_dir=$(_ymt_wtr_get_worktrees_dir)
+  if [[ $? -ne 0 || -z "$worktrees_dir" ]]; then
+    echo "Error: Failed to resolve git common directory" >&2
+    return 1
+  fi
+
   local worktree_path="${worktrees_dir}/${worktree_name}"
 
   if [[ -d "$worktree_path" ]]; then


### PR DESCRIPTION
## Summary

`wtr add` が作る worktree の配置を `<parent>/<repo>.worktrees/<name>` から `<git-common-dir>/wtr/<name>` へ変更する。親ディレクトリを汚さず、`.git` 配下なので `git status` / `git clean` / ripgrep から自動的に除外される (`.gitignore` 不要)。

## Review status

- Reviewer: with-codex
- Marker: `## 完了`
- Findings: 検出 9 件 / fix 済み 8 件

## Key Changes

### `.zsh/functions/wtr`

- 作成先を `<git-common-dir>/wtr/<name>` に変更 (例: `~/Project/Personal/dotfiles/.git/wtr/feat-x`)
- パス解決に `git rev-parse --git-common-dir` を使用。worktree 内から実行した場合や `.git` がファイル (submodule) の場合でも同一箇所へ解決される
- `git rev-parse` は未知オプションを stdout へ echo back して exit 0 するため、`--path-format` 非対応の git (< 2.31) では出力が汚染される。「1 行の絶対パス」であることを検証してから採用し、失敗時のみ `--git-common-dir` 単体の fallback へ落とす
- worktree 名の検証を追加。絶対パスと `.` / `..` 成分を拒否する
  - `..` を許すと `wtr add x ../refs/foo` で `.git/refs/foo` に worktree が作られ、git の refs を汚染する (実機で再現を確認)
  - `.` を許すと作成先が `wtr` ディレクトリ自体になり、以降の worktree がその配下にネストする
- 用途が無くなった `_ymt_wtr_get_repo_name` を削除
- help の Worktree layout を更新

### `.claude/hooks/guard-protected-files.sh`

配置変更に伴う必須の追従。このフックは `/\.git/` を含むパスを一律ブロックするため、worktree を `.git` 配下へ移すと **worktree 内の通常のソースファイルまで Edit / Write が全面的に拒否され**、help で案内している `wtr add <branch> --agent claude` が機能しなくなる。

- フック本来の意図は objects / refs など git 内部データの保護なので、worktree の作業ツリーである `<git-common-dir>/wtr/` 配下を保護対象から除外する
- worktree 直下の `.git` (= `<git-common-dir>/worktrees/<name>` へのポインター) は保護を維持する。書き換えると worktree が使用不能になるため
- `..` を含むパスは除外しない。`<repo>/.git/wtr/../config` が実際には `.git/config` を指すため、除外条件をすり抜けて git 内部データを編集できてしまう
- submodule は common-dir が `<super>/.git/modules/<submodule-path>` になるため `.git/modules/.../wtr/` も除外対象に含める。`<submodule-path>` は `libs/foo` のように複数階層を取りうる
- `.env` / lockfile はファイル名ベースの判定を維持し、worktree 内でも従来どおりブロックする
- 判定を `matches()` ヘルパーと `block` フラグに分解して整理

## Impact

### 破壊的変更

- **既存の worktree は移動しない。** 旧 `<repo>.worktrees/` 配下の worktree はそのまま残り、`wtr list` / `wtr cd` / `wtr remove` は `git worktree list` 経由なので従来どおり動作する。新規作成分のみ新レイアウトになる
- 移行する場合は `git worktree move <old> <repo>/.git/wtr/<name>` を手動実行する

### 受け入れたトレードオフ

- `rm -rf .git` する操作 (リポジトリの作り直し等) が worktree ごと巻き込む。従来の兄弟ディレクトリ方式なら生き残っていた
- `.git` を除外設定にしているバックアップ / 同期ツールでは worktree がバックアップ対象外になる

### レビューしてほしい箇所

- `guard-protected-files.sh` は `~/.claude/hooks` が本リポジトリへの symlink なので、**この PR のマージで全プロジェクトに即時反映される**。除外条件が広すぎないか
- git 内部の紛れ込み (`.git/modules/<x>/objects/wtr/` のような病的パス) は除外条件に一致するが、`..` を塞いだ現状では実害の経路が無いと判断した

## 検証

すべて使い捨てリポジトリでの実行確認。

### `wtr`

- `zsh -n .zsh/functions/wtr` 構文チェック
- `wtr add` : main 基準 / worktree 内から実行 / 重複作成の拒否 / `wtr remove`
- worktree 名の拒否: `.` / `./.` / `./` / `..` / `../refs/foo` / `a/../../b` / `/tmp/absolute` / `nested/..` の 8 パターンが rc=1、通常名と導出名は rc=0
- 拒否後に `.git/refs` が汚染されないこと
- main 側の `git status --porcelain` / `git clean -xdn` / `rg --files` に worktree が現れないこと
- 旧 git を模した shim で fallback 経路が発火すること、git 自体の失敗時に非 0 で返ること
- submodule 内で common-dir が `<super>/.git/modules/lib` に解決され、worktree が `.git/modules/lib/wtr/feat-sub` に作られること

### `guard-protected-files.sh`

- `sh -n` 構文チェック
- フック直接実行で 23 パターン (allow 7 / BLOCK 16) を確認
  - allow: worktree 内ソース、単階層/多階層/ネスト submodule の worktree 内ソース、`.git` を含まないパスの `..`
  - BLOCK: `..` バイパス 4 件、worktree 直下の `.git`、`.git/config`、`.git/refs/`、`.git/worktrees/`、`.git/objects/wtr/`、`.git/modules/lib/config`、`.git/wtrsomething/`、worktree 内外の `.env` / lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- session: host=claude-code id=c79333b0-d72f-471c-9341-0a4d865a8adf user=yuya-matsushima at=2026-08-14T13:45:01+09:00 -->
