### PR TITLE
fix(wtr): 空の skills ディレクトリを symlink しない

### DIFF
--- a/.zsh/functions/wtr
+++ b/.zsh/functions/wtr
@@ -36,7 +36,7 @@ Worktree layout:
     invisible to git status / git clean / ripgrep without any .gitignore.
     Note that removing .git also removes every worktree under it.
 
-Auto-symlinked paths (if present in main repo):
+Auto-symlinked paths (only when present and non-empty in main repo):
     .claude/skills   -> <worktree>/.claude/skills
     .agents/skills   -> <worktree>/.agents/skills
 
@@ -139,6 +139,12 @@ _ymt_wtr_symlink_skills() {
     local src="${main_worktree}/${skills_rel}"
     local dst="${worktree_path}/${skills_rel}"
     if [[ -d "$src" ]]; then
+      # 空ディレクトリ (空のサブディレクトリしか無い場合も含む) を symlink すると、
+      # git が空ディレクトリを追跡しない都合で worktree 側には untracked な symlink
+      # だけが残り git status を汚す。ファイルが 1 つでもあるときだけ symlink する。
+      if [[ -z "$(find "$src" -mindepth 1 \( -type f -o -type l \) -print -quit 2>/dev/null)" ]]; then
+        continue
+      fi
       mkdir -p "$(dirname "$dst")"
       if ln -s "$src" "$dst"; then
         echo "  Symlinked: ${skills_rel}"


### PR DESCRIPTION
## Summary

`wtr add` の skills 自動 symlink が、main repo 側のディレクトリが空でも symlink を作成していたため、worktree 側に untracked な symlink が残り `git status` を汚していた。中身があるときだけ symlink するよう修正する。

## Key Changes

- `_ymt_wtr_symlink_skills` の判定を `-d` の存在チェックのみから「ファイル (または symlink) が 1 つ以上存在するか」に変更
- 空のサブディレクトリしか無いケースも git 上は空ディレクトリと同じ扱いになるため、`find "$src" -mindepth 1 \( -type f -o -type l \) -print -quit` で再帰的に判定 (最初の 1 件で打ち切るため走査コストは最小)
- help テキストを `Auto-symlinked paths (only when present and non-empty in main repo)` に更新

## Impact

- 本リポジトリでは空の `.agents/skills` が symlink されなくなり、`wtr add` した worktree が clean な状態で始まる。`.claude/skills` は中身があるため従来どおり symlink される
- 挙動が変わるのは「main repo 側の skills ディレクトリが実質空」のケースのみ。中身のあるディレクトリの挙動は不変
- `.keep` のような隠しファイルだけを置いているディレクトリは symlink 対象のまま (git が追跡できるため)

## Test

`_ymt_wtr_symlink_skills` を直接呼び出して以下を確認済み (加えて `zsh -n` の構文チェック):

| ケース | 結果 |
|---|---|
| ファイルあり | symlink 作成 |
| 空ディレクトリ | スキップ |
| 空サブディレクトリのみ | スキップ |
| 隠しファイル (`.keep`) のみ | symlink 作成 |
| symlink のみ | symlink 作成 |
| ディレクトリ自体が無い | スキップ (従来どおり) |

<!-- session: host=claude-code id=326c4e05-7bbf-4916-86f0-f2bb7ece3c22 user=yuya-matsushima at=2026-08-14T14:25:01+09:00 -->
